### PR TITLE
fix(proxy): add HTTP proxy support for MPV and Subsonic/Jellyfin API

### DIFF
--- a/backend/app.go
+++ b/backend/app.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -366,11 +367,35 @@ func (a *App) callOnExit() error {
 	return nil
 }
 
+// resolveHTTPProxy returns the proxy URL to use for MPV playback.
+// Priority: config file > https_proxy env > HTTPS_PROXY env > empty string
+func resolveHTTPProxy(cfg LocalPlaybackConfig) string {
+	if cfg.HTTPProxy != "" {
+		return cfg.HTTPProxy
+	}
+	if proxy := os.Getenv("https_proxy"); proxy != "" {
+		return proxy
+	}
+	if proxy := os.Getenv("HTTPS_PROXY"); proxy != "" {
+		return proxy
+	}
+	return ""
+}
+
 func (a *App) initMPV() error {
 	p := mpv.NewWithClientName(a.appName)
 	c := a.Config.LocalPlayback
 	c.InMemoryCacheSizeMB = clamp(c.InMemoryCacheSizeMB, 10, 500)
-	if err := p.Init(c.InMemoryCacheSizeMB); err != nil {
+
+	// Get proxy config: config file first, environment variable as fallback
+	httpProxy := resolveHTTPProxy(c)
+
+	// Log proxy configuration for debugging (redact credentials)
+	if httpProxy != "" {
+		log.Printf("Setting MPV proxy: %s", redactProxyURL(httpProxy))
+	}
+
+	if err := p.Init(c.InMemoryCacheSizeMB, httpProxy); err != nil {
 		return fmt.Errorf("failed to initialize mpv player: %s", err.Error())
 	}
 	a.LocalPlayer = p
@@ -807,4 +832,16 @@ func isWindowsGUI() bool {
 	}
 
 	return subsystem == 2 /*IMAGE_SUBSYSTEM_WINDOWS_GUI*/
+}
+
+// redactProxyURL removes credentials from proxy URL for safe logging
+func redactProxyURL(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "<invalid URL>"
+	}
+	if u.User != nil {
+		u.User = nil
+	}
+	return u.String()
 }

--- a/backend/app.go
+++ b/backend/app.go
@@ -136,6 +136,9 @@ func StartupApp(appName, displayAppName, appVersion, appVersionTag, latestReleas
 		return nil, ErrAnotherInstance
 	}
 	a.httpClients = newAppHTTPClientFactory(a.Config.Application.HTTPProxy)
+	if a.httpClients.configuredProxyErr != nil {
+		return nil, fmt.Errorf("invalid configured HTTP proxy: %w", a.httpClients.configuredProxyErr)
+	}
 	outboundHTTPClient := a.httpClients.NewClient(0, false)
 
 	log.Printf("Starting %s...", appName)

--- a/backend/app.go
+++ b/backend/app.go
@@ -122,8 +122,6 @@ func StartupApp(appName, displayAppName, appVersion, appVersionTag, latestReleas
 	}
 	a.bgrndCtx, a.cancel = context.WithCancel(context.Background())
 	a.readConfig()
-	a.httpClients = newAppHTTPClientFactory(a.Config.Application.HTTPProxy)
-	outboundHTTPClient := a.httpClients.NewClient(0, false)
 
 	cli, _ := ipc.Connect()
 	if HaveCommandLineOptions() {
@@ -137,13 +135,15 @@ func StartupApp(appName, displayAppName, appVersion, appVersionTag, latestReleas
 		cli.Show()
 		return nil, ErrAnotherInstance
 	}
+	a.httpClients = newAppHTTPClientFactory(a.Config.Application.HTTPProxy)
+	outboundHTTPClient := a.httpClients.NewClient(0, false)
 
 	log.Printf("Starting %s...", appName)
 	log.Printf("Using config dir: %s", confDir)
 	log.Printf("Using cache dir: %s", cacheDir)
 
+	a.UpdateChecker = NewUpdateChecker(appVersionTag, latestReleaseURL, &a.Config.Application.LastCheckedVersion, outboundHTTPClient)
 	if a.Config.Application.EnableAutoUpdateChecker {
-		a.UpdateChecker = NewUpdateChecker(appVersionTag, latestReleaseURL, &a.Config.Application.LastCheckedVersion, outboundHTTPClient)
 		a.UpdateChecker.Start(a.bgrndCtx, 24*time.Hour)
 	}
 
@@ -155,7 +155,7 @@ func StartupApp(appName, displayAppName, appVersion, appVersionTag, latestReleas
 	}
 
 	a.ServerManager = NewServerManager(appName, appVersion, a.Config, !portableMode && a.Config.Application.EnablePasswordStorage, a.httpClients)
-	a.ImageManager = NewImageManager(a.bgrndCtx, a.ServerManager, cacheDir)
+	a.ImageManager = NewImageManager(a.bgrndCtx, a.ServerManager, cacheDir, outboundHTTPClient)
 	if a.Config.Playback.UseWaveformSeekbar {
 		ac, err := NewAudioCache(a.bgrndCtx, a.ServerManager, filepath.Join(cacheDir, audioCacheSubdir), outboundHTTPClient)
 		if err != nil {
@@ -324,7 +324,8 @@ func (a *App) readConfig() {
 		if cfgExists {
 			backupCfgName := fmt.Sprintf("%s.bak", configFile)
 			log.Printf("Config file may be malformed: copying to %s", backupCfgName)
-			_ = util.CopyFile(cfgPath, path.Join(a.configDir, backupCfgName))
+			backupPath := path.Join(a.configDir, backupCfgName)
+			_ = util.CopyFileWithMode(cfgPath, backupPath, 0o600)
 		}
 	}
 	a.Config = cfg
@@ -340,8 +341,11 @@ func (a *App) startConfigWriter(ctx context.Context) {
 			return
 		case <-tick.C:
 			if !reflect.DeepEqual(&a.lastWrittenCfg, a.Config) {
-				a.Config.WriteConfigFile(a.configFilePath())
-				a.lastWrittenCfg = *a.Config
+				if err := a.Config.WriteConfigFile(a.configFilePath()); err != nil {
+					log.Printf("failed to write app config file: %v", err)
+				} else {
+					a.lastWrittenCfg = *a.Config
+				}
 			}
 		}
 	}()
@@ -370,33 +374,17 @@ func (a *App) callOnExit() error {
 	return nil
 }
 
-// resolveHTTPProxy returns the proxy URL for MPV.
-// Priority: config file > https_proxy env > HTTPS_PROXY env > empty string.
-func resolveHTTPProxy(cfg AppConfig) string {
-	if cfg.HTTPProxy != "" {
-		return cfg.HTTPProxy
-	}
-	return resolveHTTPSProxyFromEnvironment()
-}
-
-func resolveHTTPSProxyFromEnvironment() string {
-	if proxy := os.Getenv("https_proxy"); proxy != "" {
-		return proxy
-	}
-	if proxy := os.Getenv("HTTPS_PROXY"); proxy != "" {
-		return proxy
-	}
-	return ""
-}
-
 func (a *App) initMPV() error {
 	p := mpv.NewWithClientName(a.appName)
 	c := a.Config.LocalPlayback
 	c.InMemoryCacheSizeMB = clamp(c.InMemoryCacheSizeMB, 10, 500)
 
-	// The application proxy takes precedence; otherwise preserve MPV's
-	// historical HTTPS environment-proxy behavior.
+	// Pass only an explicitly configured proxy; an empty value leaves
+	// proxy selection to MPV's own environment handling.
 	httpProxy := a.httpClients.proxyForMPV()
+	if err := a.httpClients.configureMPVProxyEnvironment(); err != nil {
+		return fmt.Errorf("configure MPV proxy environment: %w", err)
+	}
 
 	// Log proxy configuration for debugging (redact credentials)
 	if httpProxy != "" {
@@ -728,7 +716,10 @@ func (a *App) LoadSavedPlayQueue() error {
 }
 
 func (a *App) SaveConfigFile() {
-	a.Config.WriteConfigFile(a.configFilePath())
+	if err := a.Config.WriteConfigFile(a.configFilePath()); err != nil {
+		log.Printf("failed to write app config file: %v", err)
+		return
+	}
 	a.lastWrittenCfg = *a.Config
 }
 

--- a/backend/app.go
+++ b/backend/app.go
@@ -367,9 +367,9 @@ func (a *App) callOnExit() error {
 	return nil
 }
 
-// resolveHTTPProxy returns the proxy URL to use for MPV playback.
-// Priority: config file > https_proxy env > HTTPS_PROXY env > empty string
-func resolveHTTPProxy(cfg LocalPlaybackConfig) string {
+// resolveHTTPProxy returns the application-wide HTTP proxy URL.
+// Priority: config file > https_proxy env > HTTPS_PROXY env > empty string.
+func resolveHTTPProxy(cfg AppConfig) string {
 	if cfg.HTTPProxy != "" {
 		return cfg.HTTPProxy
 	}
@@ -387,8 +387,8 @@ func (a *App) initMPV() error {
 	c := a.Config.LocalPlayback
 	c.InMemoryCacheSizeMB = clamp(c.InMemoryCacheSizeMB, 10, 500)
 
-	// Get proxy config: config file first, environment variable as fallback
-	httpProxy := resolveHTTPProxy(c)
+	// Get the application proxy config, falling back to environment variables.
+	httpProxy := resolveHTTPProxy(a.Config.Application)
 
 	// Log proxy configuration for debugging (redact credentials)
 	if httpProxy != "" {
@@ -674,14 +674,12 @@ func (a *App) LoadSavedPlayQueue() error {
 	if isShuffle {
 		unshuffledQueueFilePath := path.Join(a.configDir, savedUnshuffledQueueFile)
 		unshuffledPlayQueue, err = LoadPlayQueue(unshuffledQueueFilePath, a.ServerManager, false)
-
 		if err != nil {
 			return err
 		}
 
 		shuffledQueueFilePath := path.Join(a.configDir, savedShuffledQueueFile)
 		shuffledPlayQueue, err = LoadPlayQueue(shuffledQueueFilePath, a.ServerManager, false)
-
 		if err != nil {
 			return err
 		}

--- a/backend/app.go
+++ b/backend/app.go
@@ -76,6 +76,7 @@ type App struct {
 	isFirstLaunch bool // set by config file reader
 	bgrndCtx      context.Context
 	cancel        context.CancelFunc
+	httpClients   *appHTTPClientFactory
 
 	lastWrittenCfg Config
 
@@ -121,6 +122,8 @@ func StartupApp(appName, displayAppName, appVersion, appVersionTag, latestReleas
 	}
 	a.bgrndCtx, a.cancel = context.WithCancel(context.Background())
 	a.readConfig()
+	a.httpClients = newAppHTTPClientFactory(a.Config.Application.HTTPProxy)
+	outboundHTTPClient := a.httpClients.NewClient(0, false)
 
 	cli, _ := ipc.Connect()
 	if HaveCommandLineOptions() {
@@ -140,7 +143,7 @@ func StartupApp(appName, displayAppName, appVersion, appVersionTag, latestReleas
 	log.Printf("Using cache dir: %s", cacheDir)
 
 	if a.Config.Application.EnableAutoUpdateChecker {
-		a.UpdateChecker = NewUpdateChecker(appVersionTag, latestReleaseURL, &a.Config.Application.LastCheckedVersion)
+		a.UpdateChecker = NewUpdateChecker(appVersionTag, latestReleaseURL, &a.Config.Application.LastCheckedVersion, outboundHTTPClient)
 		a.UpdateChecker.Start(a.bgrndCtx, 24*time.Hour)
 	}
 
@@ -151,16 +154,16 @@ func StartupApp(appName, displayAppName, appVersion, appVersionTag, latestReleas
 		return nil, err
 	}
 
-	a.ServerManager = NewServerManager(appName, appVersion, a.Config, !portableMode && a.Config.Application.EnablePasswordStorage)
+	a.ServerManager = NewServerManager(appName, appVersion, a.Config, !portableMode && a.Config.Application.EnablePasswordStorage, a.httpClients)
 	a.ImageManager = NewImageManager(a.bgrndCtx, a.ServerManager, cacheDir)
 	if a.Config.Playback.UseWaveformSeekbar {
-		ac, err := NewAudioCache(a.bgrndCtx, a.ServerManager, filepath.Join(cacheDir, audioCacheSubdir))
+		ac, err := NewAudioCache(a.bgrndCtx, a.ServerManager, filepath.Join(cacheDir, audioCacheSubdir), outboundHTTPClient)
 		if err != nil {
 			log.Printf("failed to create audio cache: %s", err.Error())
 		}
 		a.AudioCache = ac
 	}
-	a.PlaybackManager = NewPlaybackManager(a.bgrndCtx, a.ServerManager, a.AudioCache, a.LocalPlayer, &a.Config.Playback, &a.Config.Scrobbling, &a.Config.Transcoding, &a.Config.Application)
+	a.PlaybackManager = NewPlaybackManager(a.bgrndCtx, a.ServerManager, a.AudioCache, a.LocalPlayer, &a.Config.Playback, &a.Config.Scrobbling, &a.Config.Transcoding, &a.Config.Application, outboundHTTPClient)
 	a.PlaybackManager.CoverArtPathFn = func(coverArtID string) (string, error) {
 		// Ensure the thumbnail is cached on disk, then return its path so
 		// the DLNA player can expose it through the local proxy as
@@ -176,14 +179,14 @@ func StartupApp(appName, displayAppName, appVersion, appVersionTag, latestReleas
 	var fetch *LrcLibFetcher
 	if a.Config.Application.EnableLrcLib {
 		timeout := time.Duration(a.Config.Application.RequestTimeoutSeconds) * time.Second
-		fetch = NewLrcLibFetcher(a.cacheDir, a.Config.Application.CustomLrcLibUrl, timeout)
+		fetch = NewLrcLibFetcher(a.cacheDir, a.Config.Application.CustomLrcLibUrl, timeout, outboundHTTPClient)
 	}
 	a.LyricsManager = NewLyricsManager(a.ServerManager, fetch)
 	a.EQPresetManager = NewEQPresetManager(confDir)
 
 	// Initialize AutoEQ manager
 	autoEQTimeout := time.Duration(a.Config.Application.RequestTimeoutSeconds) * time.Second
-	a.AutoEQManager = NewAutoEQManager(filepath.Join(cacheDir, "autoeq"), autoEQTimeout)
+	a.AutoEQManager = NewAutoEQManager(filepath.Join(cacheDir, "autoeq"), autoEQTimeout, outboundHTTPClient)
 
 	// Periodically scan for remote players
 	go a.PlaybackManager.ScanRemotePlayers(a.bgrndCtx, true /*fastScan*/)
@@ -367,12 +370,16 @@ func (a *App) callOnExit() error {
 	return nil
 }
 
-// resolveHTTPProxy returns the application-wide HTTP proxy URL.
+// resolveHTTPProxy returns the proxy URL for MPV.
 // Priority: config file > https_proxy env > HTTPS_PROXY env > empty string.
 func resolveHTTPProxy(cfg AppConfig) string {
 	if cfg.HTTPProxy != "" {
 		return cfg.HTTPProxy
 	}
+	return resolveHTTPSProxyFromEnvironment()
+}
+
+func resolveHTTPSProxyFromEnvironment() string {
 	if proxy := os.Getenv("https_proxy"); proxy != "" {
 		return proxy
 	}
@@ -387,8 +394,9 @@ func (a *App) initMPV() error {
 	c := a.Config.LocalPlayback
 	c.InMemoryCacheSizeMB = clamp(c.InMemoryCacheSizeMB, 10, 500)
 
-	// Get the application proxy config, falling back to environment variables.
-	httpProxy := resolveHTTPProxy(a.Config.Application)
+	// The application proxy takes precedence; otherwise preserve MPV's
+	// historical HTTPS environment-proxy behavior.
+	httpProxy := a.httpClients.proxyForMPV()
 
 	// Log proxy configuration for debugging (redact credentials)
 	if httpProxy != "" {

--- a/backend/app_test.go
+++ b/backend/app_test.go
@@ -1,0 +1,88 @@
+package backend
+
+import (
+	"os"
+	"testing"
+)
+
+func TestResolveHTTPProxy(t *testing.T) {
+	// Save original environment
+	origHTTPSProxy := os.Getenv("https_proxy")
+	origHTTPSPROXY := os.Getenv("HTTPS_PROXY")
+	defer func() {
+		os.Setenv("https_proxy", origHTTPSProxy)
+		os.Setenv("HTTPS_PROXY", origHTTPSPROXY)
+	}()
+
+	// Test case 1: No proxy set
+	os.Unsetenv("https_proxy")
+	os.Unsetenv("HTTPS_PROXY")
+	
+	cfg := LocalPlaybackConfig{}
+	if proxy := resolveHTTPProxy(cfg); proxy != "" {
+		t.Errorf("Test 1: Expected empty proxy, got '%s'", proxy)
+	}
+
+	// Test case 2: Set https_proxy
+	os.Setenv("https_proxy", "http://proxy:8080")
+	if proxy := resolveHTTPProxy(cfg); proxy != "http://proxy:8080" {
+		t.Errorf("Test 2: Expected 'http://proxy:8080', got '%s'", proxy)
+	}
+
+	// Test case 3: Set HTTPS_PROXY (uppercase)
+	os.Unsetenv("https_proxy")
+	os.Setenv("HTTPS_PROXY", "http://proxy2:8080")
+	if proxy := resolveHTTPProxy(cfg); proxy != "http://proxy2:8080" {
+		t.Errorf("Test 3: Expected 'http://proxy2:8080', got '%s'", proxy)
+	}
+
+	// Test case 4: Config file takes precedence
+	cfg.HTTPProxy = "http://config-proxy:8080"
+	if proxy := resolveHTTPProxy(cfg); proxy != "http://config-proxy:8080" {
+		t.Errorf("Test 4: Expected 'http://config-proxy:8080', got '%s'", proxy)
+	}
+
+	// Test case 5: Config precedence over both env vars
+	os.Setenv("https_proxy", "http://env-proxy1:8080")
+	os.Setenv("HTTPS_PROXY", "http://env-proxy2:8080")
+	if proxy := resolveHTTPProxy(cfg); proxy != "http://config-proxy:8080" {
+		t.Errorf("Test 5: Expected 'http://config-proxy:8080', got '%s'", proxy)
+	}
+}
+
+func TestRedactProxyURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "URL with credentials",
+			input:    "http://user:pass@proxy:8080",
+			expected: "http://proxy:8080",
+		},
+		{
+			name:     "URL without credentials",
+			input:    "http://proxy:8080",
+			expected: "http://proxy:8080",
+		},
+		{
+			name:     "HTTPS URL with credentials",
+			input:    "https://user:pass@proxy:8443",
+			expected: "https://proxy:8443",
+		},
+		{
+			name:     "Invalid URL",
+			input:    "://invalid",
+			expected: "<invalid URL>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := redactProxyURL(tt.input); got != tt.expected {
+				t.Errorf("redactProxyURL(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/backend/app_test.go
+++ b/backend/app_test.go
@@ -17,7 +17,7 @@ func TestResolveHTTPProxy(t *testing.T) {
 	// Test case 1: No proxy set
 	os.Unsetenv("https_proxy")
 	os.Unsetenv("HTTPS_PROXY")
-	
+
 	cfg := LocalPlaybackConfig{}
 	if proxy := resolveHTTPProxy(cfg); proxy != "" {
 		t.Errorf("Test 1: Expected empty proxy, got '%s'", proxy)

--- a/backend/app_test.go
+++ b/backend/app_test.go
@@ -1,87 +1,22 @@
 package backend
 
-import (
-	"os"
-	"testing"
-)
-
-func TestResolveHTTPProxy(t *testing.T) {
-	// Save original environment
-	origHTTPSProxy := os.Getenv("https_proxy")
-	origHTTPSPROXY := os.Getenv("HTTPS_PROXY")
-	defer func() {
-		os.Setenv("https_proxy", origHTTPSProxy)
-		os.Setenv("HTTPS_PROXY", origHTTPSPROXY)
-	}()
-
-	// Test case 1: No proxy set
-	os.Unsetenv("https_proxy")
-	os.Unsetenv("HTTPS_PROXY")
-
-	cfg := AppConfig{}
-	if proxy := resolveHTTPProxy(cfg); proxy != "" {
-		t.Errorf("Test 1: Expected empty proxy, got '%s'", proxy)
-	}
-
-	// Test case 2: Set https_proxy
-	os.Setenv("https_proxy", "http://proxy:8080")
-	if proxy := resolveHTTPProxy(cfg); proxy != "http://proxy:8080" {
-		t.Errorf("Test 2: Expected 'http://proxy:8080', got '%s'", proxy)
-	}
-
-	// Test case 3: Set HTTPS_PROXY (uppercase)
-	os.Unsetenv("https_proxy")
-	os.Setenv("HTTPS_PROXY", "http://proxy2:8080")
-	if proxy := resolveHTTPProxy(cfg); proxy != "http://proxy2:8080" {
-		t.Errorf("Test 3: Expected 'http://proxy2:8080', got '%s'", proxy)
-	}
-
-	// Test case 4: Config file takes precedence
-	cfg.HTTPProxy = "http://config-proxy:8080"
-	if proxy := resolveHTTPProxy(cfg); proxy != "http://config-proxy:8080" {
-		t.Errorf("Test 4: Expected 'http://config-proxy:8080', got '%s'", proxy)
-	}
-
-	// Test case 5: Config precedence over both env vars
-	os.Setenv("https_proxy", "http://env-proxy1:8080")
-	os.Setenv("HTTPS_PROXY", "http://env-proxy2:8080")
-	if proxy := resolveHTTPProxy(cfg); proxy != "http://config-proxy:8080" {
-		t.Errorf("Test 5: Expected 'http://config-proxy:8080', got '%s'", proxy)
-	}
-}
+import "testing"
 
 func TestRedactProxyURL(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
-		expected string
+		name  string
+		input string
+		want  string
 	}{
-		{
-			name:     "URL with credentials",
-			input:    "http://user:pass@proxy:8080",
-			expected: "http://proxy:8080",
-		},
-		{
-			name:     "URL without credentials",
-			input:    "http://proxy:8080",
-			expected: "http://proxy:8080",
-		},
-		{
-			name:     "HTTPS URL with credentials",
-			input:    "https://user:pass@proxy:8443",
-			expected: "https://proxy:8443",
-		},
-		{
-			name:     "Invalid URL",
-			input:    "://invalid",
-			expected: "<invalid URL>",
-		},
+		{"credentials", "http://user:pass@proxy:8080", "http://proxy:8080"},
+		{"without credentials", "http://proxy:8080", "http://proxy:8080"},
+		{"https credentials", "https://user:pass@proxy:8443", "https://proxy:8443"},
+		{"invalid", "://invalid", "<invalid URL>"},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := redactProxyURL(tt.input); got != tt.expected {
-				t.Errorf("redactProxyURL(%q) = %q, want %q", tt.input, got, tt.expected)
+			if got := redactProxyURL(tt.input); got != tt.want {
+				t.Fatalf("redactProxyURL(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}

--- a/backend/app_test.go
+++ b/backend/app_test.go
@@ -18,7 +18,7 @@ func TestResolveHTTPProxy(t *testing.T) {
 	os.Unsetenv("https_proxy")
 	os.Unsetenv("HTTPS_PROXY")
 
-	cfg := LocalPlaybackConfig{}
+	cfg := AppConfig{}
 	if proxy := resolveHTTPProxy(cfg); proxy != "" {
 		t.Errorf("Test 1: Expected empty proxy, got '%s'", proxy)
 	}

--- a/backend/audiocache.go
+++ b/backend/audiocache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"net/http"
 	"os"
 	"path/filepath"
 	"slices"
@@ -21,6 +22,7 @@ type AudioCache struct {
 	s            *ServerManager
 	rootCtx      context.Context
 	baseCacheDir string
+	httpClient   *http.Client
 
 	entries map[string]*cacheEntry
 }
@@ -40,7 +42,7 @@ type AudioCacheRequest struct {
 
 // NewAudioCache initializes an AudioCache using the given context, server manager,
 // and local filesystem directory for storing audio files.
-func NewAudioCache(ctx context.Context, s *ServerManager, baseCacheDir string) (*AudioCache, error) {
+func NewAudioCache(ctx context.Context, s *ServerManager, baseCacheDir string, httpClient *http.Client) (*AudioCache, error) {
 	if err := configdir.MakePath(baseCacheDir); err != nil {
 		return nil, errors.New("failed to create audio cache dir")
 	}
@@ -48,6 +50,7 @@ func NewAudioCache(ctx context.Context, s *ServerManager, baseCacheDir string) (
 		s:            s,
 		rootCtx:      ctx,
 		baseCacheDir: baseCacheDir,
+		httpClient:   httpClient,
 		entries:      make(map[string]*cacheEntry),
 	}, nil
 }
@@ -128,7 +131,7 @@ func (a *AudioCache) cacheFile(id, dlURL string) {
 		ctx, cancel := context.WithCancel(a.rootCtx)
 		a.entries[id] = &cacheEntry{cancel: cancel}
 		go func() {
-			ok, err := sharedutil.DownloadFileWithContext(ctx, dlURL, a.pathForID(id))
+			ok, err := sharedutil.DownloadFileWithContext(ctx, a.httpClient, dlURL, a.pathForID(id))
 			if ok {
 				a.mutex.Lock()
 				if e, ok := a.entries[id]; ok {

--- a/backend/autoeq.go
+++ b/backend/autoeq.go
@@ -56,8 +56,9 @@ type AutoEQProfileMetadata struct {
 
 // AutoEQManager manages fetching and caching of AutoEQ profiles
 type AutoEQManager struct {
-	cachePath string
-	timeout   time.Duration
+	cachePath  string
+	timeout    time.Duration
+	httpClient *http.Client
 
 	// Memory cache (LRU)
 	memCache      map[string]*memoryCacheEntry
@@ -76,12 +77,13 @@ type memoryCacheEntry struct {
 }
 
 // NewAutoEQManager creates a new AutoEQ manager
-func NewAutoEQManager(cachePath string, timeout time.Duration) *AutoEQManager {
+func NewAutoEQManager(cachePath string, timeout time.Duration, httpClient *http.Client) *AutoEQManager {
 	configdir.MakePath(cachePath)
 	log.Printf("Initializing AutoEQ manager: cache=%s, timeout=%v", cachePath, timeout)
 	return &AutoEQManager{
 		cachePath:   cachePath,
 		timeout:     timeout,
+		httpClient:  httpClient,
 		memCache:    make(map[string]*memoryCacheEntry),
 		memCacheLRU: make([]string, 0, maxMemoryCacheSize),
 	}
@@ -174,7 +176,7 @@ func (m *AutoEQManager) fetchIndexFromNetwork(ctx context.Context) ([]AutoEQProf
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := m.httpClient.Do(req)
 	if err != nil {
 		log.Printf("HTTP request failed: %v", err)
 		return nil, fmt.Errorf("fetching index: %w", err)
@@ -369,7 +371,7 @@ func (m *AutoEQManager) fetchProfileFromNetwork(ctx context.Context, path string
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := m.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("fetching profile: %w", err)
 	}
@@ -391,8 +393,10 @@ func (m *AutoEQManager) fetchProfileFromNetwork(ctx context.Context, path string
 // Preamp: -6.0 dB
 // Filter 1: ON PK Fc 31 Hz Gain 5.0 dB Q 0.70
 // ... (10 filters total)
-var preampRegex = regexp.MustCompile(`Preamp:\s*([-+]?\d+\.?\d*)\s*dB`)
-var filterRegex = regexp.MustCompile(`Filter\s+\d+:.*?Fc\s+(\d+)\s+Hz.*?Gain\s+([-+]?\d+\.?\d*)\s*dB`)
+var (
+	preampRegex = regexp.MustCompile(`Preamp:\s*([-+]?\d+\.?\d*)\s*dB`)
+	filterRegex = regexp.MustCompile(`Filter\s+\d+:.*?Fc\s+(\d+)\s+Hz.*?Gain\s+([-+]?\d+\.?\d*)\s*dB`)
+)
 
 func (m *AutoEQManager) parseProfile(path string, r io.Reader) (*AutoEQProfile, error) {
 	data, err := io.ReadAll(r)

--- a/backend/config.go
+++ b/backend/config.go
@@ -143,6 +143,7 @@ type LocalPlaybackConfig struct {
 	AutoEQProfilePath     string // Path to applied AutoEQ profile (e.g., "oratory1990/over-ear/Sennheiser HD 650")
 	AutoEQProfileName     string // Display name of applied profile (e.g., "Sennheiser HD 650")
 	PauseFade             bool
+	HTTPProxy             string // HTTP/HTTPS proxy URL with optional auth (http://user:pass@proxy:8080)
 }
 
 type ScrobbleConfig struct {

--- a/backend/config.go
+++ b/backend/config.go
@@ -61,7 +61,7 @@ type AppConfig struct {
 	ShowSidebar                 bool
 	SidebarWidthFraction        float64
 	SidebarTab                  string
-	HTTPProxy                   string // HTTP/HTTPS proxy URL with optional auth (http://user:pass@proxy:8080)
+	HTTPProxy                   string // HTTP proxy URL with optional auth (http://user:pass@proxy:8080); host[:port] assumes http://
 
 	PreventScreensaverOnNowPlayingPage bool
 

--- a/backend/config.go
+++ b/backend/config.go
@@ -61,6 +61,7 @@ type AppConfig struct {
 	ShowSidebar                 bool
 	SidebarWidthFraction        float64
 	SidebarTab                  string
+	HTTPProxy                   string // HTTP/HTTPS proxy URL with optional auth (http://user:pass@proxy:8080)
 
 	PreventScreensaverOnNowPlayingPage bool
 
@@ -136,14 +137,13 @@ type LocalPlaybackConfig struct {
 	InMemoryCacheSizeMB   int
 	Volume                int
 	EqualizerEnabled      bool
-	EqualizerType         string    // "ISO10Band" or "ISO15Band"
+	EqualizerType         string // "ISO10Band" or "ISO15Band"
 	EqualizerPreamp       float64
 	GraphicEqualizerBands []float64
 	ActiveEQPresetName    string // Name of currently selected EQ preset
 	AutoEQProfilePath     string // Path to applied AutoEQ profile (e.g., "oratory1990/over-ear/Sennheiser HD 650")
 	AutoEQProfileName     string // Display name of applied profile (e.g., "Sennheiser HD 650")
 	PauseFade             bool
-	HTTPProxy             string // HTTP/HTTPS proxy URL with optional auth (http://user:pass@proxy:8080)
 }
 
 type ScrobbleConfig struct {

--- a/backend/config.go
+++ b/backend/config.go
@@ -346,9 +346,24 @@ func (c *Config) WriteConfigFile(filepath string) error {
 	if err != nil {
 		return err
 	}
-	os.WriteFile(filepath, b, 0o644)
 
-	return nil
+	// Proxy credentials may be stored in the application configuration. Tighten
+	// the file on POSIX systems; Windows access is governed by its ACLs.
+	if err := os.Chmod(filepath, 0o600); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	f, err := os.OpenFile(filepath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(b); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return os.Chmod(filepath, 0o600)
 }
 
 func (c *Config) migrateDeprecatedSettings() {

--- a/backend/config_test.go
+++ b/backend/config_test.go
@@ -1,0 +1,51 @@
+package backend
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHTTPProxyConfigSerialization(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.toml")
+
+	configContent := `
+[LocalPlayback]
+HTTPProxy = "http://user:pass@proxy:8080"
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	cfg, err := ReadConfigFile(configPath, "test")
+	if err != nil {
+		t.Fatalf("Failed to read config file: %v", err)
+	}
+
+	if cfg.LocalPlayback.HTTPProxy != "http://user:pass@proxy:8080" {
+		t.Errorf("Expected HTTPProxy 'http://user:pass@proxy:8080', got '%s'", cfg.LocalPlayback.HTTPProxy)
+	}
+}
+
+func TestHTTPProxyConfigDefault(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.toml")
+
+	configContent := `
+[LocalPlayback]
+Volume = 50
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	cfg, err := ReadConfigFile(configPath, "test")
+	if err != nil {
+		t.Fatalf("Failed to read config file: %v", err)
+	}
+
+	if cfg.LocalPlayback.HTTPProxy != "" {
+		t.Errorf("Expected empty HTTPProxy, got '%s'", cfg.LocalPlayback.HTTPProxy)
+	}
+}

--- a/backend/config_test.go
+++ b/backend/config_test.go
@@ -11,7 +11,7 @@ func TestHTTPProxyConfigSerialization(t *testing.T) {
 	configPath := filepath.Join(tempDir, "config.toml")
 
 	configContent := `
-[LocalPlayback]
+[Application]
 HTTPProxy = "http://user:pass@proxy:8080"
 `
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
@@ -23,8 +23,8 @@ HTTPProxy = "http://user:pass@proxy:8080"
 		t.Fatalf("Failed to read config file: %v", err)
 	}
 
-	if cfg.LocalPlayback.HTTPProxy != "http://user:pass@proxy:8080" {
-		t.Errorf("Expected HTTPProxy 'http://user:pass@proxy:8080', got '%s'", cfg.LocalPlayback.HTTPProxy)
+	if cfg.Application.HTTPProxy != "http://user:pass@proxy:8080" {
+		t.Errorf("Expected HTTPProxy 'http://user:pass@proxy:8080', got '%s'", cfg.Application.HTTPProxy)
 	}
 }
 
@@ -33,8 +33,8 @@ func TestHTTPProxyConfigDefault(t *testing.T) {
 	configPath := filepath.Join(tempDir, "config.toml")
 
 	configContent := `
-[LocalPlayback]
-Volume = 50
+[Application]
+Language = "auto"
 `
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
 		t.Fatalf("Failed to write config file: %v", err)
@@ -45,7 +45,7 @@ Volume = 50
 		t.Fatalf("Failed to read config file: %v", err)
 	}
 
-	if cfg.LocalPlayback.HTTPProxy != "" {
-		t.Errorf("Expected empty HTTPProxy, got '%s'", cfg.LocalPlayback.HTTPProxy)
+	if cfg.Application.HTTPProxy != "" {
+		t.Errorf("Expected empty HTTPProxy, got '%s'", cfg.Application.HTTPProxy)
 	}
 }

--- a/backend/httpclient.go
+++ b/backend/httpclient.go
@@ -1,0 +1,93 @@
+package backend
+
+import (
+	"crypto/tls"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// appHTTPClientFactory creates outbound HTTP clients with the application
+// proxy setting applied. When no application proxy is configured, it leaves
+// the default transport's ProxyFromEnvironment behavior intact.
+type appHTTPClientFactory struct {
+	configuredProxy    *url.URL
+	hasConfiguredProxy bool
+}
+
+func newAppHTTPClientFactory(rawProxy string) *appHTTPClientFactory {
+	factory := &appHTTPClientFactory{}
+	if rawProxy == "" {
+		return factory
+	}
+
+	factory.hasConfiguredProxy = true
+	proxy, err := parseHTTPProxyURL(rawProxy)
+	if err != nil {
+		log.Printf("Warning: invalid proxy URL %q, ignoring proxy: %s", redactProxyURL(rawProxy), err)
+		return factory
+	}
+
+	factory.configuredProxy = proxy
+	log.Printf("Setting application HTTP proxy: %s", redactProxyURL(rawProxy))
+	return factory
+}
+
+func parseHTTPProxyURL(rawProxy string) (*url.URL, error) {
+	proxy, err := url.Parse(rawProxy)
+	if err != nil {
+		return nil, err
+	}
+	if proxy.Host == "" || (proxy.Scheme != "http" && proxy.Scheme != "https") {
+		return nil, fmt.Errorf("proxy URL must use http or https and include a host")
+	}
+	return proxy, nil
+}
+
+func (f *appHTTPClientFactory) NewClient(timeout time.Duration, skipSSLVerify bool) *http.Client {
+	client := &http.Client{Timeout: timeout}
+	f.configureHTTPClient(client, skipSSLVerify)
+	return client
+}
+
+func (f *appHTTPClientFactory) configureHTTPClient(client *http.Client, skipSSLVerify bool) {
+	var transport *http.Transport
+	if existing, ok := client.Transport.(*http.Transport); ok {
+		transport = existing.Clone()
+	} else {
+		transport = http.DefaultTransport.(*http.Transport).Clone()
+	}
+
+	switch {
+	case f.configuredProxy != nil:
+		transport.Proxy = http.ProxyURL(f.configuredProxy)
+	case f.hasConfiguredProxy:
+		// A configured but invalid proxy must not silently fall back to an
+		// environment proxy.
+		transport.Proxy = nil
+	}
+
+	if skipSSLVerify {
+		if transport.TLSClientConfig == nil {
+			transport.TLSClientConfig = &tls.Config{}
+		} else {
+			transport.TLSClientConfig = transport.TLSClientConfig.Clone()
+		}
+		transport.TLSClientConfig.InsecureSkipVerify = true
+	}
+	client.Transport = transport
+}
+
+// proxyForMPV returns the configured proxy, or the HTTPS environment proxy
+// that MPV historically honored when no application proxy is configured.
+func (f *appHTTPClientFactory) proxyForMPV() string {
+	if f.configuredProxy != nil {
+		return f.configuredProxy.String()
+	}
+	if f.hasConfiguredProxy {
+		return ""
+	}
+	return resolveHTTPSProxyFromEnvironment()
+}

--- a/backend/httpclient.go
+++ b/backend/httpclient.go
@@ -6,15 +6,23 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"os"
+	"strings"
 	"time"
+
+	"golang.org/x/net/http/httpproxy"
 )
 
 // appHTTPClientFactory creates outbound HTTP clients with the application
-// proxy setting applied. When no application proxy is configured, it leaves
-// the default transport's ProxyFromEnvironment behavior intact.
+// proxy setting applied. Configured proxies use httpproxy semantics so
+// NO_PROXY and loopback exemptions remain in effect; without an application
+// proxy, the default transport's environment behavior is preserved.
 type appHTTPClientFactory struct {
-	configuredProxy    *url.URL
-	hasConfiguredProxy bool
+	configuredProxy     *url.URL
+	configuredProxyFunc func(*url.URL) (*url.URL, error)
+	hasConfiguredProxy  bool
+	configuredProxyErr  error
+	mpvProxyErr         error
 }
 
 func newAppHTTPClientFactory(rawProxy string) *appHTTPClientFactory {
@@ -22,25 +30,46 @@ func newAppHTTPClientFactory(rawProxy string) *appHTTPClientFactory {
 	if rawProxy == "" {
 		return factory
 	}
-
-	factory.hasConfiguredProxy = true
 	proxy, err := parseHTTPProxyURL(rawProxy)
 	if err != nil {
-		log.Printf("Warning: invalid proxy URL %q, ignoring proxy: %s", redactProxyURL(rawProxy), err)
+		log.Printf("Warning: invalid proxy configuration, ignoring configured proxy")
+		factory.hasConfiguredProxy = true
+		factory.configuredProxyErr = err
 		return factory
 	}
+	factory.hasConfiguredProxy = true
 
+	envProxy := httpproxy.FromEnvironment()
+	proxyConfig := &httpproxy.Config{
+		HTTPProxy:  proxy.String(),
+		HTTPSProxy: proxy.String(),
+		NoProxy:    envProxy.NoProxy,
+	}
 	factory.configuredProxy = proxy
-	log.Printf("Setting application HTTP proxy: %s", redactProxyURL(rawProxy))
+	factory.configuredProxyFunc = proxyConfig.ProxyFunc()
+	if proxy.Scheme == "https" {
+		factory.mpvProxyErr = fmt.Errorf("configured proxy uses HTTPS, which MPV does not support")
+	}
+	log.Printf("Setting application HTTP proxy: %s", redactProxyURL(proxy.String()))
 	return factory
 }
 
 func parseHTTPProxyURL(rawProxy string) (*url.URL, error) {
+	rawProxy = strings.TrimSpace(rawProxy)
+	if rawProxy == "" {
+		return nil, fmt.Errorf("proxy URL is empty")
+	}
+	if !strings.Contains(rawProxy, "://") {
+		// Match httpproxy's host[:port] form by assuming http:// when the
+		// configured value omits a scheme.
+		rawProxy = "http://" + rawProxy
+	}
 	proxy, err := url.Parse(rawProxy)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid proxy URL")
 	}
-	if proxy.Host == "" || (proxy.Scheme != "http" && proxy.Scheme != "https") {
+	proxy.Scheme = strings.ToLower(proxy.Scheme)
+	if proxy.Host == "" || proxy.Hostname() == "" || (proxy.Scheme != "http" && proxy.Scheme != "https") {
 		return nil, fmt.Errorf("proxy URL must use http or https and include a host")
 	}
 	return proxy, nil
@@ -61,8 +90,8 @@ func (f *appHTTPClientFactory) configureHTTPClient(client *http.Client, skipSSLV
 	}
 
 	switch {
-	case f.configuredProxy != nil:
-		transport.Proxy = http.ProxyURL(f.configuredProxy)
+	case f.configuredProxyFunc != nil:
+		transport.Proxy = f.proxyForRequest
 	case f.hasConfiguredProxy:
 		// A configured but invalid proxy must not silently fall back to an
 		// environment proxy.
@@ -80,14 +109,58 @@ func (f *appHTTPClientFactory) configureHTTPClient(client *http.Client, skipSSLV
 	client.Transport = transport
 }
 
-// proxyForMPV returns the configured proxy, or the HTTPS environment proxy
-// that MPV historically honored when no application proxy is configured.
+// proxyForMPV returns a configured HTTP proxy URL when MPV supports it.
+// Go clients may support HTTPS proxy endpoints, but MPV's option does not.
 func (f *appHTTPClientFactory) proxyForMPV() string {
-	if f.configuredProxy != nil {
-		return f.configuredProxy.String()
-	}
-	if f.hasConfiguredProxy {
+	if f.configuredProxy == nil || f.configuredProxy.Scheme != "http" {
 		return ""
 	}
-	return resolveHTTPSProxyFromEnvironment()
+	return f.configuredProxy.String()
+}
+
+// validateMPVProxy rejects configured proxy forms that MPV would otherwise
+// silently ignore. MPV accepts HTTP proxy URLs, while the Go clients also
+// support HTTPS proxy URLs.
+func (f *appHTTPClientFactory) validateMPVProxy() error {
+	if f.configuredProxyErr != nil {
+		return fmt.Errorf("invalid configured proxy")
+	}
+	return f.mpvProxyErr
+}
+
+// configureMPVProxyEnvironment keeps MPV/FFmpeg's no_proxy environment in
+// sync with the application proxy. MPV does not receive Go's implicit
+// loopback exemption, so add the loopback host literals explicitly while
+// preserving existing entries. CIDR entries are preserved, but MPV/FFmpeg
+// may not support every NO_PROXY form that Go's httpproxy package supports.
+func (f *appHTTPClientFactory) configureMPVProxyEnvironment() error {
+	if f.configuredProxy == nil {
+		return nil
+	}
+
+	parts := make([]string, 0, 8)
+	seen := make(map[string]struct{}, 8)
+	for _, value := range []string{os.Getenv("no_proxy"), os.Getenv("NO_PROXY"), "localhost", "127.0.0.1", "::1"} {
+		for _, entry := range strings.Split(value, ",") {
+			entry = strings.TrimSpace(entry)
+			if entry == "" {
+				continue
+			}
+			key := strings.ToLower(entry)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			parts = append(parts, entry)
+		}
+	}
+	noProxy := strings.Join(parts, ",")
+	if err := os.Setenv("no_proxy", noProxy); err != nil {
+		return err
+	}
+	return os.Setenv("NO_PROXY", noProxy)
+}
+
+func (f *appHTTPClientFactory) proxyForRequest(req *http.Request) (*url.URL, error) {
+	return f.configuredProxyFunc(req.URL)
 }

--- a/backend/httpclient.go
+++ b/backend/httpclient.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -14,25 +15,26 @@ import (
 )
 
 // appHTTPClientFactory creates outbound HTTP clients with the application
-// proxy setting applied. Configured proxies use httpproxy semantics so
-// NO_PROXY and loopback exemptions remain in effect; without an application
-// proxy, the default transport's environment behavior is preserved.
+// HTTP proxy setting applied. A configured HTTP endpoint is used for both
+// HTTP and HTTPS requests; without one, the transport keeps environment
+// proxy semantics intact.
 type appHTTPClientFactory struct {
 	configuredProxy     *url.URL
 	configuredProxyFunc func(*url.URL) (*url.URL, error)
 	hasConfiguredProxy  bool
 	configuredProxyErr  error
-	mpvProxyErr         error
 }
 
 func newAppHTTPClientFactory(rawProxy string) *appHTTPClientFactory {
 	factory := &appHTTPClientFactory{}
+	rawProxy = strings.TrimSpace(rawProxy)
 	if rawProxy == "" {
 		return factory
 	}
+
 	proxy, err := parseHTTPProxyURL(rawProxy)
 	if err != nil {
-		log.Printf("Warning: invalid proxy configuration, ignoring configured proxy")
+		log.Printf("Warning: invalid configured HTTP proxy; refusing to start with proxy configuration")
 		factory.hasConfiguredProxy = true
 		factory.configuredProxyErr = err
 		return factory
@@ -47,9 +49,6 @@ func newAppHTTPClientFactory(rawProxy string) *appHTTPClientFactory {
 	}
 	factory.configuredProxy = proxy
 	factory.configuredProxyFunc = proxyConfig.ProxyFunc()
-	if proxy.Scheme == "https" {
-		factory.mpvProxyErr = fmt.Errorf("configured proxy uses HTTPS, which MPV does not support")
-	}
 	log.Printf("Setting application HTTP proxy: %s", redactProxyURL(proxy.String()))
 	return factory
 }
@@ -60,8 +59,7 @@ func parseHTTPProxyURL(rawProxy string) (*url.URL, error) {
 		return nil, fmt.Errorf("proxy URL is empty")
 	}
 	if !strings.Contains(rawProxy, "://") {
-		// Match httpproxy's host[:port] form by assuming http:// when the
-		// configured value omits a scheme.
+		// Treat a host[:port] value as an HTTP proxy, matching httpproxy.
 		rawProxy = "http://" + rawProxy
 	}
 	proxy, err := url.Parse(rawProxy)
@@ -69,10 +67,50 @@ func parseHTTPProxyURL(rawProxy string) (*url.URL, error) {
 		return nil, fmt.Errorf("invalid proxy URL")
 	}
 	proxy.Scheme = strings.ToLower(proxy.Scheme)
-	if proxy.Host == "" || proxy.Hostname() == "" || (proxy.Scheme != "http" && proxy.Scheme != "https") {
-		return nil, fmt.Errorf("proxy URL must use http or https and include a host")
+	if proxy.Host == "" || proxy.Hostname() == "" || proxy.Scheme != "http" {
+		return nil, fmt.Errorf("proxy URL must use the http scheme and include a host")
+	}
+	if err := validateHTTPProxyPort(proxy.Host); err != nil {
+		return nil, err
 	}
 	return proxy, nil
+}
+
+func validateHTTPProxyPort(host string) error {
+	var rawPort string
+	switch {
+	case strings.HasPrefix(host, "["):
+		closeBracket := strings.LastIndexByte(host, ']')
+		if closeBracket < 0 {
+			return fmt.Errorf("proxy URL has malformed host")
+		}
+		if len(host) == closeBracket+1 {
+			return nil
+		}
+		if host[closeBracket+1] != ':' {
+			return fmt.Errorf("proxy URL has malformed port")
+		}
+		rawPort = host[closeBracket+2:]
+	case strings.Count(host, ":") == 0:
+		return nil
+	case strings.Count(host, ":") == 1:
+		rawPort = host[strings.LastIndexByte(host, ':')+1:]
+	default:
+		return fmt.Errorf("proxy URL has malformed host or port")
+	}
+	if rawPort == "" {
+		return fmt.Errorf("proxy URL has an empty port")
+	}
+	for _, char := range rawPort {
+		if char < '0' || char > '9' {
+			return fmt.Errorf("proxy URL port must be numeric")
+		}
+	}
+	port, err := strconv.Atoi(rawPort)
+	if err != nil || port < 1 || port > 65535 {
+		return fmt.Errorf("proxy URL port must be between 1 and 65535")
+	}
+	return nil
 }
 
 func (f *appHTTPClientFactory) NewClient(timeout time.Duration, skipSSLVerify bool) *http.Client {
@@ -109,23 +147,13 @@ func (f *appHTTPClientFactory) configureHTTPClient(client *http.Client, skipSSLV
 	client.Transport = transport
 }
 
-// proxyForMPV returns a configured HTTP proxy URL when MPV supports it.
-// Go clients may support HTTPS proxy endpoints, but MPV's option does not.
+// proxyForMPV returns the configured HTTP proxy URL. An empty return value
+// leaves proxy selection to MPV's own environment handling.
 func (f *appHTTPClientFactory) proxyForMPV() string {
-	if f.configuredProxy == nil || f.configuredProxy.Scheme != "http" {
+	if f.configuredProxy == nil {
 		return ""
 	}
 	return f.configuredProxy.String()
-}
-
-// validateMPVProxy rejects configured proxy forms that MPV would otherwise
-// silently ignore. MPV accepts HTTP proxy URLs, while the Go clients also
-// support HTTPS proxy URLs.
-func (f *appHTTPClientFactory) validateMPVProxy() error {
-	if f.configuredProxyErr != nil {
-		return fmt.Errorf("invalid configured proxy")
-	}
-	return f.mpvProxyErr
 }
 
 // configureMPVProxyEnvironment keeps MPV/FFmpeg's no_proxy environment in

--- a/backend/imagemanager.go
+++ b/backend/imagemanager.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"image"
 	"image/jpeg"
+	"io"
 	"io/fs"
 	"log"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -17,7 +19,6 @@ import (
 	"strings"
 	"time"
 
-	"fyne.io/fyne/v2"
 	"github.com/20after4/configdir"
 	"github.com/google/uuid"
 )
@@ -36,6 +37,7 @@ const (
 // and a larger on-disc cache of images that is periodically re-requested from the server.
 type ImageManager struct {
 	s              *ServerManager
+	httpClient     *http.Client
 	baseCacheDir   string
 	thumbnailCache ImageCache
 
@@ -50,13 +52,14 @@ type ImageManager struct {
 }
 
 // NewImageManager returns a new ImageManager.
-func NewImageManager(ctx context.Context, s *ServerManager, baseCacheDir string) *ImageManager {
+func NewImageManager(ctx context.Context, s *ServerManager, baseCacheDir string, httpClient *http.Client) *ImageManager {
 	if err := configdir.MakePath(baseCacheDir); err != nil {
 		log.Println("failed to create album cover cache dir")
 		baseCacheDir = ""
 	}
 	i := &ImageManager{
 		s:            s,
+		httpClient:   httpClient,
 		baseCacheDir: baseCacheDir,
 		thumbnailCache: ImageCache{
 			MinSize:    24,
@@ -217,17 +220,18 @@ func (i *ImageManager) ensureArtistCoverCacheDir() string {
 
 func (i *ImageManager) fetchRemoteArtistImage(url string) (image.Image, error) {
 	i.serverFetchSema <- struct{}{} // acquire
-	res, err := fyne.LoadResourceFromURLString(url)
-	<-i.serverFetchSema // release
-
-	if err == nil {
-		im, _, err := image.Decode(bytes.NewReader(res.Content()))
-		if err == nil {
-			return im, nil
-		}
+	defer func() { <-i.serverFetchSema }()
+	resp, err := i.httpClient.Get(url)
+	if err != nil {
 		return nil, err
 	}
-	return nil, err
+	defer resp.Body.Close()
+	res, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	im, _, err := image.Decode(bytes.NewReader(res))
+	return im, err
 }
 
 func (i *ImageManager) fetchAndCacheCoverFromDiskOrServer(ctx context.Context, coverID string, ttl time.Duration, cb func(image.Image, error)) (image.Image, error) {

--- a/backend/lrclib.go
+++ b/backend/lrclib.go
@@ -27,12 +27,13 @@ type LrcLibFetcher struct {
 	cachePath       string
 	customLrcLibUrl string
 	timeout         time.Duration
+	httpClient      *http.Client
 }
 
-func NewLrcLibFetcher(baseCacheDir string, customLrcLibUrl string, timeout time.Duration) *LrcLibFetcher {
+func NewLrcLibFetcher(baseCacheDir string, customLrcLibUrl string, timeout time.Duration, httpClient *http.Client) *LrcLibFetcher {
 	cachePath := filepath.Join(baseCacheDir, lrclibCacheFolder)
 	configdir.MakePath(cachePath)
-	return &LrcLibFetcher{cachePath: cachePath, customLrcLibUrl: customLrcLibUrl, timeout: timeout}
+	return &LrcLibFetcher{cachePath: cachePath, customLrcLibUrl: customLrcLibUrl, timeout: timeout, httpClient: httpClient}
 }
 
 func (l *LrcLibFetcher) FetchLrcLibLyrics(name, artist, album string, durationSecs int) (*mediaprovider.Lyrics, error) {
@@ -103,7 +104,7 @@ func (l *LrcLibFetcher) fetchFromServer(name, artist, album string, durationSecs
 	q.Add("duration", strconv.Itoa(durationSecs))
 	req.URL.RawQuery = q.Encode()
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := l.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/mediaprovider/jellyfin/jellyfinmediaprovider.go
+++ b/backend/mediaprovider/jellyfin/jellyfinmediaprovider.go
@@ -4,6 +4,7 @@ import (
 	"image"
 	"io"
 	"math"
+	"net/http"
 	"sync"
 	"time"
 
@@ -41,6 +42,7 @@ var _ mediaprovider.MediaProvider = (*JellyfinMediaProvider)(nil)
 
 type JellyfinMediaProvider struct {
 	client          *jellyfin.Client
+	downloadClient  *http.Client
 	prefetchCoverCB func(coverArtID string)
 
 	currentLibraryID string
@@ -50,9 +52,13 @@ type JellyfinMediaProvider struct {
 }
 
 func newJellyfinMediaProvider(cli *jellyfin.Client) mediaprovider.MediaProvider {
+	downloadClient := *cli.HTTPClient
+	downloadClient.Timeout = 0
+
 	return &JellyfinMediaProvider{
-		client:       cli,
-		genresCached: make([]*mediaprovider.Genre, 0),
+		client:         cli,
+		downloadClient: &downloadClient,
+		genresCached:   make([]*mediaprovider.Genre, 0),
 	}
 }
 
@@ -370,12 +376,12 @@ func (j *JellyfinMediaProvider) GetStreamURL(trackID string, transcode *mediapro
 	return j.client.GetStreamURL(trackID, jfTranscode)
 }
 
-func (j *JellyfinMediaProvider) DownloadTrack(trackID string) (io.Reader, error) {
+func (j *JellyfinMediaProvider) DownloadTrack(trackID string) (io.ReadCloser, error) {
 	url, err := j.client.GetStreamURL(trackID, nil)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := j.client.HTTPClient.Get(url)
+	resp, err := j.downloadClient.Get(url)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/mediaprovider/jellyfin/jellyfinmediaprovider.go
+++ b/backend/mediaprovider/jellyfin/jellyfinmediaprovider.go
@@ -4,7 +4,6 @@ import (
 	"image"
 	"io"
 	"math"
-	"net/http"
 	"sync"
 	"time"
 
@@ -376,7 +375,7 @@ func (j *JellyfinMediaProvider) DownloadTrack(trackID string) (io.Reader, error)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := http.Get(url)
+	resp, err := j.client.HTTPClient.Get(url)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/mediaprovider/jellyfin/jellyfinmediaprovider_test.go
+++ b/backend/mediaprovider/jellyfin/jellyfinmediaprovider_test.go
@@ -3,8 +3,10 @@ package jellyfin
 import (
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	jellyfinapi "github.com/dweymouth/go-jellyfin"
 )
@@ -33,11 +35,13 @@ func TestDownloadTrackUsesProviderHTTPClient(t *testing.T) {
 		t.Fatalf("creating Jellyfin client: %v", err)
 	}
 
-	provider := &JellyfinMediaProvider{client: client}
+	provider := newJellyfinMediaProvider(client).(*JellyfinMediaProvider)
 	reader, err := provider.DownloadTrack("track-id")
 	if err != nil {
 		t.Fatalf("downloading track: %v", err)
 	}
+	defer reader.Close()
+
 	body, err := io.ReadAll(reader)
 	if err != nil {
 		t.Fatalf("reading track: %v", err)
@@ -47,5 +51,56 @@ func TestDownloadTrackUsesProviderHTTPClient(t *testing.T) {
 	}
 	if string(body) != "track" {
 		t.Fatalf("track body = %q, want %q", body, "track")
+	}
+}
+
+func TestDownloadTrackDoesNotInheritAPITimeout(t *testing.T) {
+	const apiTimeout = 200 * time.Millisecond
+	const bodyDelay = 2 * apiTimeout
+	const track = "slow track"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		time.Sleep(bodyDelay)
+		_, _ = io.WriteString(w, track)
+	}))
+	defer server.Close()
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	defer transport.CloseIdleConnections()
+	apiHTTPClient := &http.Client{
+		Transport: transport,
+		Timeout:   apiTimeout,
+	}
+	client, err := jellyfinapi.NewClient(server.URL, "test", "1", jellyfinapi.WithHTTPClient(apiHTTPClient))
+	if err != nil {
+		t.Fatalf("creating Jellyfin client: %v", err)
+	}
+	provider := newJellyfinMediaProvider(client).(*JellyfinMediaProvider)
+	if provider.downloadClient == apiHTTPClient {
+		t.Fatal("download client must not reuse the API client")
+	}
+	if got, want := provider.downloadClient.Transport, apiHTTPClient.Transport; got != want {
+		t.Fatalf("download transport = %p, want API transport %p", got, want)
+	}
+	if got := provider.downloadClient.Timeout; got != 0 {
+		t.Fatalf("download client timeout = %v, want 0", got)
+	}
+	if got := apiHTTPClient.Timeout; got != apiTimeout {
+		t.Fatalf("API client timeout = %v, want %v", got, apiTimeout)
+	}
+
+	reader, err := provider.DownloadTrack("track-id")
+	if err != nil {
+		t.Fatalf("downloading track: %v", err)
+	}
+	defer reader.Close()
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("reading slow track: %v", err)
+	}
+	if string(body) != track {
+		t.Fatalf("track body = %q, want %q", body, track)
 	}
 }

--- a/backend/mediaprovider/jellyfin/jellyfinmediaprovider_test.go
+++ b/backend/mediaprovider/jellyfin/jellyfinmediaprovider_test.go
@@ -1,0 +1,51 @@
+package jellyfin
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	jellyfinapi "github.com/dweymouth/go-jellyfin"
+)
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestDownloadTrackUsesProviderHTTPClient(t *testing.T) {
+	var requestedPath string
+	client, err := jellyfinapi.NewClient("http://music.example.test", "test", "1", jellyfinapi.WithHTTPClient(&http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			requestedPath = req.URL.Path
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Body:       io.NopCloser(strings.NewReader("track")),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}),
+	}))
+	if err != nil {
+		t.Fatalf("creating Jellyfin client: %v", err)
+	}
+
+	provider := &JellyfinMediaProvider{client: client}
+	reader, err := provider.DownloadTrack("track-id")
+	if err != nil {
+		t.Fatalf("downloading track: %v", err)
+	}
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("reading track: %v", err)
+	}
+	if requestedPath != "/audio/track-id/stream" {
+		t.Fatalf("request path = %q, want stream endpoint", requestedPath)
+	}
+	if string(body) != "track" {
+		t.Fatalf("track body = %q, want %q", body, "track")
+	}
+}

--- a/backend/mediaprovider/mediaprovider.go
+++ b/backend/mediaprovider/mediaprovider.go
@@ -283,7 +283,7 @@ type MediaProvider interface {
 
 	TrackEndedPlayback(trackID string, positionSecs int, submission bool) error
 
-	DownloadTrack(trackID string) (io.Reader, error)
+	DownloadTrack(trackID string) (io.ReadCloser, error)
 
 	RescanLibrary() error
 }

--- a/backend/mediaprovider/subsonic/subsonicmediaprovider.go
+++ b/backend/mediaprovider/subsonic/subsonicmediaprovider.go
@@ -397,7 +397,7 @@ func (s *subsonicMediaProvider) CanShareArtists() bool {
 	return false
 }
 
-func (s *subsonicMediaProvider) DownloadTrack(trackID string) (io.Reader, error) {
+func (s *subsonicMediaProvider) DownloadTrack(trackID string) (io.ReadCloser, error) {
 	return s.client.Download(trackID)
 }
 

--- a/backend/playbackengine.go
+++ b/backend/playbackengine.go
@@ -746,7 +746,7 @@ func (p *playbackEngine) RemoveTracksFromQueue(idxs []int) {
 		newPlayQueue := make([]mediaprovider.MediaItem, 0, p.getPlayQueueLength()-len(idxs))
 		for _, tr := range p.getPlayQueue() {
 			if slices.Contains(ids, tr.Metadata().ID) {
-				//remove id from id list, handles having the same track present multiple times in playQueue
+				// remove id from id list, handles having the same track present multiple times in playQueue
 				idx := slices.Index(ids, tr.Metadata().ID)
 				ids = slices.Delete(ids, idx, idx+1)
 			} else {
@@ -921,7 +921,6 @@ func (p *playbackEngine) handleOnTrackChange() {
 		p.Pause()
 		p.SetPauseAfterCurrent(false)
 	}
-
 }
 
 func (p *playbackEngine) handleOnStopped() {

--- a/backend/playbackmanager.go
+++ b/backend/playbackmanager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"net/http"
 	"runtime"
 	"slices"
 	"sync"
@@ -24,12 +25,13 @@ import (
 // A high-level MediaProvider-aware playback engine, serves as an
 // intermediary between the frontend and various Player backends.
 type PlaybackManager struct {
-	engine   *playbackEngine
-	wfmGen   *WaveformImageGenerator
-	cache    *AudioCache
-	cmdQueue *playbackCommandQueue
-	appCfg   *AppConfig
-	cfg      *PlaybackConfig
+	engine            *playbackEngine
+	wfmGen            *WaveformImageGenerator
+	cache             *AudioCache
+	cmdQueue          *playbackCommandQueue
+	appCfg            *AppConfig
+	musicServerClient *http.Client
+	cfg               *PlaybackConfig
 
 	// CoverArtPathFn returns a local filesystem path to the cached cover
 	// art image for the given CoverArtID. Used by DLNA cast so the
@@ -76,16 +78,18 @@ func NewPlaybackManager(
 	scrobbleCfg *ScrobbleConfig,
 	transcodeCfg *TranscodingConfig,
 	appCfg *AppConfig,
+	musicServerClient *http.Client,
 ) *PlaybackManager {
 	e := NewPlaybackEngine(ctx, s, c, p, playbackCfg, scrobbleCfg, transcodeCfg)
 	q := NewCommandQueue()
 	pm := &PlaybackManager{
-		engine:      e,
-		cmdQueue:    q,
-		appCfg:      appCfg,
-		cfg:         playbackCfg,
-		localPlayer: p,
-		cache:       c,
+		engine:            e,
+		cmdQueue:          q,
+		appCfg:            appCfg,
+		musicServerClient: musicServerClient,
+		cfg:               playbackCfg,
+		localPlayer:       p,
+		cache:             c,
 	}
 	if c != nil {
 		pm.wfmGen = NewWaveformImageGenerator(c)
@@ -261,7 +265,7 @@ func (p *PlaybackManager) scanRemotePlayers(ctx context.Context, waitSec int) {
 			URL:      d.URL,
 			Protocol: "DLNA",
 			new: func() (player.BasePlayer, error) {
-				return dlna.NewDLNAPlayer(d, coverArtPathFn)
+				return dlna.NewDLNAPlayer(d, coverArtPathFn, p.musicServerClient)
 			},
 		}
 		discovered = append(discovered, rp)
@@ -568,9 +572,8 @@ func (p *PlaybackManager) PlayRandomSongs(genreName string) error {
 		}
 		return sharedutil.FilterSlice(tr, func(t *mediaprovider.Track) bool {
 			skipKwd := p.cfg.SkipKeywordWhenShuffling
-			include :=
-				(skipKwd == "" || !strcase.Contains(t.Title, skipKwd)) &&
-					(!p.cfg.SkipOneStarWhenShuffling || t.Rating != 1)
+			include := (skipKwd == "" || !strcase.Contains(t.Title, skipKwd)) &&
+				(!p.cfg.SkipOneStarWhenShuffling || t.Rating != 1)
 			return include
 		}), nil
 	})
@@ -825,9 +828,8 @@ func (p *PlaybackManager) enqueueAutoplayTracks() {
 
 	filterAutoplayTracks := func(tracks []*mediaprovider.Track) []*mediaprovider.Track {
 		return sharedutil.FilterSlice(tracks, func(t *mediaprovider.Track) bool {
-			shouldSkip :=
-				(p.cfg.SkipOneStarWhenShuffling && t.Rating == 1) ||
-					(p.cfg.SkipKeywordWhenShuffling != "" && strcase.Contains(t.Title, p.cfg.SkipKeywordWhenShuffling))
+			shouldSkip := (p.cfg.SkipOneStarWhenShuffling && t.Rating == 1) ||
+				(p.cfg.SkipKeywordWhenShuffling != "" && strcase.Contains(t.Title, p.cfg.SkipKeywordWhenShuffling))
 			recentlyPlayed := slices.ContainsFunc(queue, func(i mediaprovider.MediaItem) bool {
 				return i.Metadata().Type == mediaprovider.MediaItemTypeTrack && i.Metadata().ID == t.ID
 			})

--- a/backend/player/dlna/dlnaplayer.go
+++ b/backend/player/dlna/dlnaplayer.go
@@ -50,7 +50,8 @@ type DLNAPlayer struct {
 	// available. When set and the resolver succeeds, the path is exposed
 	// through the local proxy and emitted as upnp:albumArtURI in DIDL-Lite
 	// so the renderer can fetch it.
-	coverArtPathFn func(coverArtID string) (string, error)
+	coverArtPathFn    func(coverArtID string) (string, error)
+	musicServerClient *http.Client
 
 	state   int // stopped, playing, paused
 	seeking bool
@@ -95,11 +96,8 @@ type DLNAPlayer struct {
 	resetChan   chan (time.Duration)
 }
 
-func NewDLNAPlayer(device *device.MediaRenderer, coverArtPathFn func(coverArtID string) (string, error)) (*DLNAPlayer, error) {
-	retry := retryablehttp.NewClient()
-	retry.RetryMax = 3
-	retry.RetryWaitMin = 100 * time.Millisecond
-	retry.Logger = retryLogger{}
+func NewDLNAPlayer(device *device.MediaRenderer, coverArtPathFn func(coverArtID string) (string, error), musicServerClient *http.Client) (*DLNAPlayer, error) {
+	retry := newRendererRetryClient()
 	cli := retry.StandardClient()
 
 	avt, err := device.AVTransportClient()
@@ -121,11 +119,25 @@ func NewDLNAPlayer(device *device.MediaRenderer, coverArtPathFn func(coverArtID 
 	}
 
 	return &DLNAPlayer{
-		avTransport:    avt,
-		renderControl:  rc,
-		resetChan:      make(chan time.Duration),
-		coverArtPathFn: coverArtPathFn,
+		avTransport:       avt,
+		renderControl:     rc,
+		resetChan:         make(chan time.Duration),
+		coverArtPathFn:    coverArtPathFn,
+		musicServerClient: musicServerClient,
 	}, nil
+}
+
+func newRendererRetryClient() *retryablehttp.Client {
+	retry := retryablehttp.NewClient()
+	retry.RetryMax = 3
+	retry.RetryWaitMin = 100 * time.Millisecond
+	retry.Logger = retryLogger{}
+	if transport, ok := retry.HTTPClient.Transport.(*http.Transport); ok {
+		// Renderer control endpoints are on the local network and must not
+		// inherit application or environment proxy settings.
+		transport.Proxy = nil
+	}
+	return retry
 }
 
 // buildMediaItem assembles the avtransport.MediaItem for a track. It
@@ -611,9 +623,8 @@ func (d *DLNAPlayer) handleRequest(w http.ResponseWriter, r *http.Request) {
 	// Copy headers from the original request to the new request
 	proxyReq.Header = r.Header
 
-	// Create an HTTP client and send the request
-	client := &http.Client{}
-	resp, err := client.Do(proxyReq)
+	// Forward only music-server requests through the injected outbound client.
+	resp, err := d.musicServerClient.Do(proxyReq)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return

--- a/backend/player/dlna/dlnaplayer_test.go
+++ b/backend/player/dlna/dlnaplayer_test.go
@@ -1,0 +1,56 @@
+package dlna
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestHandleRequestUsesMusicServerClient(t *testing.T) {
+	var requestedURL string
+	musicServerClient := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		requestedURL = req.URL.String()
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       io.NopCloser(strings.NewReader("stream")),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})}
+	player := &DLNAPlayer{musicServerClient: musicServerClient}
+	key := player.addURLToProxy("http://music.example.test/stream")
+
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "http://renderer.local/"+key, nil)
+	player.handleRequest(response, request)
+
+	if requestedURL != "http://music.example.test/stream" {
+		t.Fatalf("forwarded URL = %q, want music server URL", requestedURL)
+	}
+	if response.Code != http.StatusOK {
+		t.Fatalf("response status = %d, want %d", response.Code, http.StatusOK)
+	}
+	if response.Body.String() != "stream" {
+		t.Fatalf("response body = %q, want %q", response.Body.String(), "stream")
+	}
+}
+
+func TestRendererRetryClientDoesNotProxyLocalControl(t *testing.T) {
+	retry := newRendererRetryClient()
+	transport, ok := retry.HTTPClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("renderer transport = %T, want *http.Transport", retry.HTTPClient.Transport)
+	}
+	if transport.Proxy != nil {
+		t.Fatal("renderer control client has a proxy configured")
+	}
+}

--- a/backend/player/mpv/player.go
+++ b/backend/player/mpv/player.go
@@ -100,7 +100,7 @@ func NewWithClientName(c string) *Player {
 
 // Initializes the Player and makes it ready for playback.
 // Most Player functions will return ErrUnitialized if called before Init.
-func (p *Player) Init(maxCacheMB int) error {
+func (p *Player) Init(maxCacheMB int, httpProxy string) error {
 	if !p.initialized {
 		m := mpv.Create()
 
@@ -130,6 +130,10 @@ func (p *Player) Init(maxCacheMB int) error {
 
 		if p.clientName != "" {
 			m.SetOptionString("audio-client-name", p.clientName)
+		}
+
+		if httpProxy != "" {
+			m.SetOptionString("http-proxy", httpProxy)
 		}
 
 		m.ObserveProperty(0, "metadata", mpv.FORMAT_NODE)

--- a/backend/servermanager.go
+++ b/backend/servermanager.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -187,6 +188,7 @@ func (s *ServerManager) connect(connection ServerConnection, password string) (m
 		connection.Hostname = NormalizeServerURL(connection.Hostname)
 		connection.AltHostname = NormalizeServerURL(connection.AltHostname)
 	}
+	httpProxy := resolveHTTPProxy(s.config.LocalPlayback)
 
 	if connection.ServerType == ServerTypeJellyfin {
 		client, err := jellyfin.NewClient(connection.Hostname, res.AppName, res.AppVersion, jellyfin.WithTimeout(timeout))
@@ -194,7 +196,7 @@ func (s *ServerManager) connect(connection ServerConnection, password string) (m
 			log.Printf("error creating Jellyfin client: %s", err.Error())
 			return nil, err
 		}
-		s.checkSetInsecureSkipVerify(connection.SkipSSLVerify, client.HTTPClient)
+		applyTransportSettings(client.HTTPClient, httpProxy, connection.SkipSSLVerify)
 		cli = &jellyfinMP.JellyfinServer{
 			Client: *client,
 		}
@@ -205,7 +207,7 @@ func (s *ServerManager) connect(connection ServerConnection, password string) (m
 				log.Printf("error creating Jellyfin alternative client: %s", err.Error())
 				return nil, err
 			}
-			s.checkSetInsecureSkipVerify(connection.SkipSSLVerify, altClient.HTTPClient)
+			applyTransportSettings(altClient.HTTPClient, httpProxy, connection.SkipSSLVerify)
 			altCli = &jellyfinMP.JellyfinServer{
 				Client: *altClient,
 			}
@@ -215,7 +217,7 @@ func (s *ServerManager) connect(connection ServerConnection, password string) (m
 		cli = &subsonicMP.SubsonicServer{
 			Client: subsonic.Client{
 				UserAgent:    ua,
-				Client:       &http.Client{Timeout: timeout},
+				Client:       newHTTPClient(timeout, httpProxy, connection.SkipSSLVerify),
 				BaseUrl:      connection.Hostname,
 				User:         connection.Username,
 				PasswordAuth: connection.LegacyAuth,
@@ -223,11 +225,10 @@ func (s *ServerManager) connect(connection ServerConnection, password string) (m
 				UseJSON:      true,
 			},
 		}
-		s.checkSetInsecureSkipVerify(connection.SkipSSLVerify, cli.(*subsonicMP.SubsonicServer).Client.Client)
 		altCli = &subsonicMP.SubsonicServer{
 			Client: subsonic.Client{
 				UserAgent:    ua,
-				Client:       &http.Client{Timeout: timeout},
+				Client:       newHTTPClient(timeout, httpProxy, connection.SkipSSLVerify),
 				BaseUrl:      connection.AltHostname,
 				User:         connection.Username,
 				PasswordAuth: connection.LegacyAuth,
@@ -235,7 +236,6 @@ func (s *ServerManager) connect(connection ServerConnection, password string) (m
 				UseJSON:      true,
 			},
 		}
-		s.checkSetInsecureSkipVerify(connection.SkipSSLVerify, altCli.(*subsonicMP.SubsonicServer).Client.Client)
 	}
 
 	// struct to return hostname type in isAlt and connection success on err
@@ -282,12 +282,37 @@ func (s *ServerManager) connect(connection ServerConnection, password string) (m
 	}
 }
 
-func (s *ServerManager) checkSetInsecureSkipVerify(skip bool, cli *http.Client) {
-	if skip {
-		cli.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+func newHTTPClient(timeout time.Duration, proxyURL string, skipSSLVerify bool) *http.Client {
+	client := &http.Client{Timeout: timeout}
+	applyTransportSettings(client, proxyURL, skipSSLVerify)
+	return client
+}
+
+func applyTransportSettings(cli *http.Client, proxyURL string, skipSSLVerify bool) {
+	var transport *http.Transport
+	if cli.Transport != nil {
+		if t, ok := cli.Transport.(*http.Transport); ok {
+			transport = t.Clone()
+		} else {
+			transport = http.DefaultTransport.(*http.Transport).Clone()
+		}
+	} else {
+		transport = http.DefaultTransport.(*http.Transport).Clone()
+	}
+
+	if proxyURL != "" {
+		proxy, err := url.Parse(proxyURL)
+		if err != nil {
+			log.Printf("Warning: invalid proxy URL %q, ignoring proxy: %s", redactProxyURL(proxyURL), err.Error())
+		} else {
+			transport.Proxy = http.ProxyURL(proxy)
+			log.Printf("Setting API client proxy: %s", redactProxyURL(proxyURL))
 		}
 	}
+	if skipSSLVerify {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+	cli.Transport = transport
 }
 
 func (a *ServerManager) GetServer() mediaprovider.MediaProvider {

--- a/backend/servermanager.go
+++ b/backend/servermanager.go
@@ -2,12 +2,9 @@ package backend
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"log"
-	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -31,18 +28,20 @@ type ServerManager struct {
 	appName           string
 	appVersion        string
 	config            *Config
+	httpClients       *appHTTPClientFactory
 	onServerConnected []func(*ServerConfig)
 	onLogout          []func()
 }
 
 var ErrUnreachable = errors.New("server is unreachable")
 
-func NewServerManager(appName, appVersion string, config *Config, useKeyring bool) *ServerManager {
+func NewServerManager(appName, appVersion string, config *Config, useKeyring bool, httpClients *appHTTPClientFactory) *ServerManager {
 	return &ServerManager{
-		appName:    appName,
-		appVersion: appVersion,
-		config:     config,
-		useKeyring: useKeyring,
+		appName:     appName,
+		appVersion:  appVersion,
+		config:      config,
+		useKeyring:  useKeyring,
+		httpClients: httpClients,
 	}
 }
 
@@ -188,26 +187,23 @@ func (s *ServerManager) connect(connection ServerConnection, password string) (m
 		connection.Hostname = NormalizeServerURL(connection.Hostname)
 		connection.AltHostname = NormalizeServerURL(connection.AltHostname)
 	}
-	httpProxy := resolveHTTPProxy(s.config.Application)
 
 	if connection.ServerType == ServerTypeJellyfin {
-		client, err := jellyfin.NewClient(connection.Hostname, res.AppName, res.AppVersion, jellyfin.WithTimeout(timeout))
+		client, err := jellyfin.NewClient(connection.Hostname, res.AppName, res.AppVersion, jellyfin.WithHTTPClient(s.httpClients.NewClient(timeout, connection.SkipSSLVerify)))
 		if err != nil {
 			log.Printf("error creating Jellyfin client: %s", err.Error())
 			return nil, err
 		}
-		applyTransportSettings(client.HTTPClient, httpProxy, connection.SkipSSLVerify)
 		cli = &jellyfinMP.JellyfinServer{
 			Client: *client,
 		}
 
 		if connection.AltHostname != "" {
-			altClient, err := jellyfin.NewClient(connection.AltHostname, res.AppName, res.AppVersion, jellyfin.WithTimeout(timeout))
+			altClient, err := jellyfin.NewClient(connection.AltHostname, res.AppName, res.AppVersion, jellyfin.WithHTTPClient(s.httpClients.NewClient(timeout, connection.SkipSSLVerify)))
 			if err != nil {
 				log.Printf("error creating Jellyfin alternative client: %s", err.Error())
 				return nil, err
 			}
-			applyTransportSettings(altClient.HTTPClient, httpProxy, connection.SkipSSLVerify)
 			altCli = &jellyfinMP.JellyfinServer{
 				Client: *altClient,
 			}
@@ -217,7 +213,7 @@ func (s *ServerManager) connect(connection ServerConnection, password string) (m
 		cli = &subsonicMP.SubsonicServer{
 			Client: subsonic.Client{
 				UserAgent:    ua,
-				Client:       newHTTPClient(timeout, httpProxy, connection.SkipSSLVerify),
+				Client:       s.httpClients.NewClient(timeout, connection.SkipSSLVerify),
 				BaseUrl:      connection.Hostname,
 				User:         connection.Username,
 				PasswordAuth: connection.LegacyAuth,
@@ -228,7 +224,7 @@ func (s *ServerManager) connect(connection ServerConnection, password string) (m
 		altCli = &subsonicMP.SubsonicServer{
 			Client: subsonic.Client{
 				UserAgent:    ua,
-				Client:       newHTTPClient(timeout, httpProxy, connection.SkipSSLVerify),
+				Client:       s.httpClients.NewClient(timeout, connection.SkipSSLVerify),
 				BaseUrl:      connection.AltHostname,
 				User:         connection.Username,
 				PasswordAuth: connection.LegacyAuth,
@@ -280,39 +276,6 @@ func (s *ServerManager) connect(connection ServerConnection, password string) (m
 		}
 		return cli, res.err
 	}
-}
-
-func newHTTPClient(timeout time.Duration, proxyURL string, skipSSLVerify bool) *http.Client {
-	client := &http.Client{Timeout: timeout}
-	applyTransportSettings(client, proxyURL, skipSSLVerify)
-	return client
-}
-
-func applyTransportSettings(cli *http.Client, proxyURL string, skipSSLVerify bool) {
-	var transport *http.Transport
-	if cli.Transport != nil {
-		if t, ok := cli.Transport.(*http.Transport); ok {
-			transport = t.Clone()
-		} else {
-			transport = http.DefaultTransport.(*http.Transport).Clone()
-		}
-	} else {
-		transport = http.DefaultTransport.(*http.Transport).Clone()
-	}
-
-	if proxyURL != "" {
-		proxy, err := url.Parse(proxyURL)
-		if err != nil {
-			log.Printf("Warning: invalid proxy URL %q, ignoring proxy: %s", redactProxyURL(proxyURL), err.Error())
-		} else {
-			transport.Proxy = http.ProxyURL(proxy)
-			log.Printf("Setting API client proxy: %s", redactProxyURL(proxyURL))
-		}
-	}
-	if skipSSLVerify {
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	}
-	cli.Transport = transport
 }
 
 func (a *ServerManager) GetServer() mediaprovider.MediaProvider {

--- a/backend/servermanager.go
+++ b/backend/servermanager.go
@@ -188,7 +188,7 @@ func (s *ServerManager) connect(connection ServerConnection, password string) (m
 		connection.Hostname = NormalizeServerURL(connection.Hostname)
 		connection.AltHostname = NormalizeServerURL(connection.AltHostname)
 	}
-	httpProxy := resolveHTTPProxy(s.config.LocalPlayback)
+	httpProxy := resolveHTTPProxy(s.config.Application)
 
 	if connection.ServerType == ServerTypeJellyfin {
 		client, err := jellyfin.NewClient(connection.Hostname, res.AppName, res.AppVersion, jellyfin.WithTimeout(timeout))

--- a/backend/servermanager_test.go
+++ b/backend/servermanager_test.go
@@ -1,6 +1,12 @@
 package backend
 
-import "testing"
+import (
+	"crypto/tls"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+)
 
 func TestNormalizeServerURL(t *testing.T) {
 	tests := []struct {
@@ -45,5 +51,188 @@ func TestNormalizeJellyfinURL(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("NormalizeJellyfinURL(%q) = %q, want %q", tt.input, got, tt.want)
 		}
+	}
+}
+
+func TestNewHTTPClient_ProxyOnly(t *testing.T) {
+	testNewHTTPClient(t, newHTTPClientTestCase{
+		timeout:          3 * time.Second,
+		proxy:            "http://proxy.example.com:8080",
+		wantProxy:        "http://proxy.example.com:8080",
+		wantSkipSSL:      false,
+		wantTLSConfigNil: true,
+	})
+}
+
+func TestNewHTTPClient_ProxyAndSkipSSL(t *testing.T) {
+	testNewHTTPClient(t, newHTTPClientTestCase{
+		timeout:     3 * time.Second,
+		proxy:       "http://proxy.example.com:8080",
+		skipSSL:     true,
+		wantProxy:   "http://proxy.example.com:8080",
+		wantSkipSSL: true,
+	})
+}
+
+func TestNewHTTPClient_SkipSSLOnly(t *testing.T) {
+	testNewHTTPClient(t, newHTTPClientTestCase{
+		timeout:     3 * time.Second,
+		skipSSL:     true,
+		wantSkipSSL: true,
+	})
+}
+
+func TestNewHTTPClient_InvalidProxy(t *testing.T) {
+	testNewHTTPClient(t, newHTTPClientTestCase{
+		timeout:          3 * time.Second,
+		proxy:            "http://%zz",
+		wantSkipSSL:      false,
+		wantTLSConfigNil: true,
+	})
+}
+
+func TestNewHTTPClient_EmptyProxy(t *testing.T) {
+	testNewHTTPClient(t, newHTTPClientTestCase{
+		timeout:          3 * time.Second,
+		proxy:            "",
+		wantSkipSSL:      false,
+		wantTLSConfigNil: true,
+	})
+}
+
+type newHTTPClientTestCase struct {
+	timeout          time.Duration
+	proxy            string
+	skipSSL          bool
+	wantProxy        string
+	wantSkipSSL      bool
+	wantTLSConfigNil bool
+}
+
+func testNewHTTPClient(t *testing.T, tc newHTTPClientTestCase) {
+	t.Helper()
+
+	client := newHTTPClient(tc.timeout, tc.proxy, tc.skipSSL)
+
+	if client.Timeout != tc.timeout {
+		t.Fatalf("client timeout = %s, want %s", client.Timeout, tc.timeout)
+	}
+
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("client transport = %T, want *http.Transport", client.Transport)
+	}
+
+	requestURL, err := url.Parse("http://music.example.com/rest/ping")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if tc.wantProxy == "" {
+		if transport.Proxy != nil {
+			proxyURL, err := transport.Proxy(&http.Request{URL: requestURL})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if proxyURL != nil {
+				t.Fatalf("proxy URL = %q, want nil", proxyURL.String())
+			}
+		}
+	} else {
+		if transport.Proxy == nil {
+			t.Fatal("transport Proxy = nil, want proxy function")
+		}
+		proxyURL, err := transport.Proxy(&http.Request{URL: requestURL})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if proxyURL == nil {
+			t.Fatal("proxy URL = nil, want configured proxy")
+		}
+		if got := proxyURL.String(); got != tc.wantProxy {
+			t.Fatalf("proxy URL = %q, want %q", got, tc.wantProxy)
+		}
+	}
+
+	if tc.wantTLSConfigNil {
+		if transport.TLSClientConfig != nil {
+			t.Fatal("transport TLSClientConfig is set, want nil")
+		}
+		return
+	}
+
+	if transport.TLSClientConfig == nil {
+		t.Fatal("transport TLSClientConfig = nil, want config")
+	}
+	if transport.TLSClientConfig.InsecureSkipVerify != tc.wantSkipSSL {
+		t.Fatalf("transport TLSClientConfig.InsecureSkipVerify = %t, want %t", transport.TLSClientConfig.InsecureSkipVerify, tc.wantSkipSSL)
+	}
+}
+
+func TestApplyTransportSettingsIgnoresInvalidProxyAndPreservesTimeout(t *testing.T) {
+	client := &http.Client{Timeout: 7 * time.Second}
+
+	applyTransportSettings(client, "http://%zz", true)
+
+	if client.Timeout != 7*time.Second {
+		t.Fatalf("client timeout = %s, want %s", client.Timeout, 7*time.Second)
+	}
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("client transport = %T, want *http.Transport", client.Transport)
+	}
+	if transport.Proxy != nil {
+		t.Fatal("transport Proxy is set for invalid proxy URL, want nil")
+	}
+	if transport.TLSClientConfig == nil || !transport.TLSClientConfig.InsecureSkipVerify {
+		t.Fatal("transport TLSClientConfig.InsecureSkipVerify = false, want true")
+	}
+}
+
+func TestApplyTransportSettingsDoesNotSetTLSConfigWhenSkipSSLVerifyDisabled(t *testing.T) {
+	client := &http.Client{}
+	client.Transport = &http.Transport{TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12}}
+
+	applyTransportSettings(client, "", false)
+
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("client transport = %T, want *http.Transport", client.Transport)
+	}
+	if transport.Proxy != nil {
+		t.Fatal("transport Proxy is set without a proxy URL, want nil")
+	}
+	if transport.TLSClientConfig == nil {
+		t.Fatal("transport TLSClientConfig was not preserved from original transport")
+	}
+	if transport.TLSClientConfig.InsecureSkipVerify {
+		t.Fatal("transport TLSClientConfig.InsecureSkipVerify = true, want false")
+	}
+}
+
+func TestApplyTransportSettingsClonesExistingTransport(t *testing.T) {
+	existing := &http.Transport{
+		MaxIdleConns:        42,
+		MaxIdleConnsPerHost: 7,
+	}
+	client := &http.Client{Transport: existing}
+
+	applyTransportSettings(client, "http://proxy.example.com:8080", true)
+
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("client transport = %T, want *http.Transport", client.Transport)
+	}
+	if transport == existing {
+		t.Fatal("transport was reused, want cloned transport")
+	}
+	if transport.MaxIdleConns != existing.MaxIdleConns {
+		t.Fatalf("MaxIdleConns = %d, want %d", transport.MaxIdleConns, existing.MaxIdleConns)
+	}
+	if transport.MaxIdleConnsPerHost != existing.MaxIdleConnsPerHost {
+		t.Fatalf("MaxIdleConnsPerHost = %d, want %d", transport.MaxIdleConnsPerHost, existing.MaxIdleConnsPerHost)
+	}
+	if transport.TLSClientConfig == nil || !transport.TLSClientConfig.InsecureSkipVerify {
+		t.Fatal("transport TLSClientConfig.InsecureSkipVerify = false, want true")
 	}
 }

--- a/backend/servermanager_test.go
+++ b/backend/servermanager_test.go
@@ -56,11 +56,10 @@ func TestNormalizeJellyfinURL(t *testing.T) {
 
 func TestNewHTTPClient_ProxyOnly(t *testing.T) {
 	testNewHTTPClient(t, newHTTPClientTestCase{
-		timeout:          3 * time.Second,
-		proxy:            "http://proxy.example.com:8080",
-		wantProxy:        "http://proxy.example.com:8080",
-		wantSkipSSL:      false,
-		wantTLSConfigNil: true,
+		timeout:     3 * time.Second,
+		proxy:       "http://proxy.example.com:8080",
+		wantProxy:   "http://proxy.example.com:8080",
+		wantSkipSSL: false,
 	})
 }
 
@@ -84,29 +83,26 @@ func TestNewHTTPClient_SkipSSLOnly(t *testing.T) {
 
 func TestNewHTTPClient_InvalidProxy(t *testing.T) {
 	testNewHTTPClient(t, newHTTPClientTestCase{
-		timeout:          3 * time.Second,
-		proxy:            "http://%zz",
-		wantSkipSSL:      false,
-		wantTLSConfigNil: true,
+		timeout:     3 * time.Second,
+		proxy:       "http://%zz",
+		wantSkipSSL: false,
 	})
 }
 
 func TestNewHTTPClient_EmptyProxy(t *testing.T) {
 	testNewHTTPClient(t, newHTTPClientTestCase{
-		timeout:          3 * time.Second,
-		proxy:            "",
-		wantSkipSSL:      false,
-		wantTLSConfigNil: true,
+		timeout:     3 * time.Second,
+		proxy:       "",
+		wantSkipSSL: false,
 	})
 }
 
 type newHTTPClientTestCase struct {
-	timeout          time.Duration
-	proxy            string
-	skipSSL          bool
-	wantProxy        string
-	wantSkipSSL      bool
-	wantTLSConfigNil bool
+	timeout     time.Duration
+	proxy       string
+	skipSSL     bool
+	wantProxy   string
+	wantSkipSSL bool
 }
 
 func testNewHTTPClient(t *testing.T, tc newHTTPClientTestCase) {
@@ -154,15 +150,11 @@ func testNewHTTPClient(t *testing.T, tc newHTTPClientTestCase) {
 		}
 	}
 
-	if tc.wantTLSConfigNil {
-		if transport.TLSClientConfig != nil {
-			t.Fatal("transport TLSClientConfig is set, want nil")
+	if transport.TLSClientConfig == nil {
+		if tc.wantSkipSSL {
+			t.Fatal("transport TLSClientConfig = nil, want InsecureSkipVerify enabled")
 		}
 		return
-	}
-
-	if transport.TLSClientConfig == nil {
-		t.Fatal("transport TLSClientConfig = nil, want config")
 	}
 	if transport.TLSClientConfig.InsecureSkipVerify != tc.wantSkipSSL {
 		t.Fatalf("transport TLSClientConfig.InsecureSkipVerify = %t, want %t", transport.TLSClientConfig.InsecureSkipVerify, tc.wantSkipSSL)
@@ -181,8 +173,18 @@ func TestApplyTransportSettingsIgnoresInvalidProxyAndPreservesTimeout(t *testing
 	if !ok {
 		t.Fatalf("client transport = %T, want *http.Transport", client.Transport)
 	}
+	requestURL, err := url.Parse("http://music.example.com/rest/ping")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if transport.Proxy != nil {
-		t.Fatal("transport Proxy is set for invalid proxy URL, want nil")
+		proxyURL, err := transport.Proxy(&http.Request{URL: requestURL})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if proxyURL != nil {
+			t.Fatalf("proxy URL = %q for invalid proxy configuration, want nil", proxyURL.String())
+		}
 	}
 	if transport.TLSClientConfig == nil || !transport.TLSClientConfig.InsecureSkipVerify {
 		t.Fatal("transport TLSClientConfig.InsecureSkipVerify = false, want true")

--- a/backend/servermanager_test.go
+++ b/backend/servermanager_test.go
@@ -66,6 +66,15 @@ func TestAppHTTPClientFactoryConfiguredProxy(t *testing.T) {
 	})
 }
 
+func TestAppHTTPClientFactoryAddsMissingProxyScheme(t *testing.T) {
+	testNewHTTPClient(t, newHTTPClientTestCase{
+		timeout:     3 * time.Second,
+		proxy:       "proxy.example.com:8080",
+		wantProxy:   "http://proxy.example.com:8080",
+		wantSkipSSL: false,
+	})
+}
+
 func TestAppHTTPClientFactoryConfiguredProxyAndSkipSSL(t *testing.T) {
 	testNewHTTPClient(t, newHTTPClientTestCase{
 		timeout:     3 * time.Second,
@@ -97,6 +106,49 @@ func TestAppHTTPClientFactoryUsesEnvironmentProxyWithoutConfiguration(t *testing
 		timeout:     3 * time.Second,
 		wantSkipSSL: false,
 	})
+}
+
+func TestAppHTTPClientFactoryConfiguredProxyHonorsNoProxy(t *testing.T) {
+	t.Setenv("NO_PROXY", "music.example.com")
+	client := newAppHTTPClientFactory("http://proxy.example.com:8080").NewClient(time.Second, false)
+	transport := client.Transport.(*http.Transport)
+	requestURL, err := url.Parse("http://music.example.com/rest/ping")
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxyURL, err := transport.Proxy(&http.Request{URL: requestURL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if proxyURL != nil {
+		t.Fatalf("proxy URL = %q, want direct connection from NO_PROXY", proxyURL)
+	}
+}
+
+func TestAppHTTPClientFactoryConfiguredProxyBypassesLoopback(t *testing.T) {
+	client := newAppHTTPClientFactory("http://proxy.example.com:8080").NewClient(time.Second, false)
+	transport := client.Transport.(*http.Transport)
+	requestURL, err := url.Parse("http://127.0.0.1:4533/rest/ping")
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxyURL, err := transport.Proxy(&http.Request{URL: requestURL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if proxyURL != nil {
+		t.Fatalf("proxy URL = %q, want direct loopback connection", proxyURL)
+	}
+}
+
+func TestAppHTTPClientFactoryMPVUsesOnlyConfiguredProxy(t *testing.T) {
+	t.Setenv("HTTPS_PROXY", "http://environment.example.com:8080")
+	if got := newAppHTTPClientFactory("").proxyForMPV(); got != "" {
+		t.Fatalf("proxyForMPV() = %q without configuration, want empty", got)
+	}
+	if got := newAppHTTPClientFactory("proxy.example.com:8080").proxyForMPV(); got != "http://proxy.example.com:8080" {
+		t.Fatalf("proxyForMPV() = %q, want normalized configured proxy", got)
+	}
 }
 
 type newHTTPClientTestCase struct {

--- a/backend/servermanager_test.go
+++ b/backend/servermanager_test.go
@@ -2,8 +2,11 @@ package backend
 
 import (
 	"crypto/tls"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -54,7 +57,7 @@ func TestNormalizeJellyfinURL(t *testing.T) {
 	}
 }
 
-func TestNewHTTPClient_ProxyOnly(t *testing.T) {
+func TestAppHTTPClientFactoryConfiguredProxy(t *testing.T) {
 	testNewHTTPClient(t, newHTTPClientTestCase{
 		timeout:     3 * time.Second,
 		proxy:       "http://proxy.example.com:8080",
@@ -63,7 +66,7 @@ func TestNewHTTPClient_ProxyOnly(t *testing.T) {
 	})
 }
 
-func TestNewHTTPClient_ProxyAndSkipSSL(t *testing.T) {
+func TestAppHTTPClientFactoryConfiguredProxyAndSkipSSL(t *testing.T) {
 	testNewHTTPClient(t, newHTTPClientTestCase{
 		timeout:     3 * time.Second,
 		proxy:       "http://proxy.example.com:8080",
@@ -73,7 +76,7 @@ func TestNewHTTPClient_ProxyAndSkipSSL(t *testing.T) {
 	})
 }
 
-func TestNewHTTPClient_SkipSSLOnly(t *testing.T) {
+func TestAppHTTPClientFactorySkipSSLOnly(t *testing.T) {
 	testNewHTTPClient(t, newHTTPClientTestCase{
 		timeout:     3 * time.Second,
 		skipSSL:     true,
@@ -81,7 +84,7 @@ func TestNewHTTPClient_SkipSSLOnly(t *testing.T) {
 	})
 }
 
-func TestNewHTTPClient_InvalidProxy(t *testing.T) {
+func TestAppHTTPClientFactoryInvalidProxy(t *testing.T) {
 	testNewHTTPClient(t, newHTTPClientTestCase{
 		timeout:     3 * time.Second,
 		proxy:       "http://%zz",
@@ -89,10 +92,9 @@ func TestNewHTTPClient_InvalidProxy(t *testing.T) {
 	})
 }
 
-func TestNewHTTPClient_EmptyProxy(t *testing.T) {
+func TestAppHTTPClientFactoryUsesEnvironmentProxyWithoutConfiguration(t *testing.T) {
 	testNewHTTPClient(t, newHTTPClientTestCase{
 		timeout:     3 * time.Second,
-		proxy:       "",
 		wantSkipSSL: false,
 	})
 }
@@ -108,7 +110,7 @@ type newHTTPClientTestCase struct {
 func testNewHTTPClient(t *testing.T, tc newHTTPClientTestCase) {
 	t.Helper()
 
-	client := newHTTPClient(tc.timeout, tc.proxy, tc.skipSSL)
+	client := newAppHTTPClientFactory(tc.proxy).NewClient(tc.timeout, tc.skipSSL)
 
 	if client.Timeout != tc.timeout {
 		t.Fatalf("client timeout = %s, want %s", client.Timeout, tc.timeout)
@@ -123,22 +125,13 @@ func testNewHTTPClient(t *testing.T, tc newHTTPClientTestCase) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	req := &http.Request{URL: requestURL}
 
-	if tc.wantProxy == "" {
-		if transport.Proxy != nil {
-			proxyURL, err := transport.Proxy(&http.Request{URL: requestURL})
-			if err != nil {
-				t.Fatal(err)
-			}
-			if proxyURL != nil {
-				t.Fatalf("proxy URL = %q, want nil", proxyURL.String())
-			}
-		}
-	} else {
+	if tc.wantProxy != "" {
 		if transport.Proxy == nil {
-			t.Fatal("transport Proxy = nil, want proxy function")
+			t.Fatal("transport Proxy = nil, want configured proxy function")
 		}
-		proxyURL, err := transport.Proxy(&http.Request{URL: requestURL})
+		proxyURL, err := transport.Proxy(req)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -147,6 +140,26 @@ func testNewHTTPClient(t *testing.T, tc newHTTPClientTestCase) {
 		}
 		if got := proxyURL.String(); got != tc.wantProxy {
 			t.Fatalf("proxy URL = %q, want %q", got, tc.wantProxy)
+		}
+	} else if tc.proxy != "" {
+		if transport.Proxy != nil {
+			t.Fatal("transport Proxy is set for an invalid proxy configuration")
+		}
+	} else {
+		defaultTransport := http.DefaultTransport.(*http.Transport)
+		if transport.Proxy == nil || defaultTransport.Proxy == nil {
+			t.Fatal("transport Proxy = nil, want default environment proxy semantics")
+		}
+		gotProxy, gotErr := transport.Proxy(req)
+		wantProxy, wantErr := defaultTransport.Proxy(req)
+		if (gotErr == nil) != (wantErr == nil) || (gotErr != nil && gotErr.Error() != wantErr.Error()) {
+			t.Fatalf("environment proxy error = %v, want %v", gotErr, wantErr)
+		}
+		if (gotProxy == nil) != (wantProxy == nil) {
+			t.Fatalf("environment proxy = %v, want %v", gotProxy, wantProxy)
+		}
+		if gotProxy != nil && gotProxy.String() != wantProxy.String() {
+			t.Fatalf("environment proxy = %q, want %q", gotProxy, wantProxy)
 		}
 	}
 
@@ -161,10 +174,8 @@ func testNewHTTPClient(t *testing.T, tc newHTTPClientTestCase) {
 	}
 }
 
-func TestApplyTransportSettingsIgnoresInvalidProxyAndPreservesTimeout(t *testing.T) {
-	client := &http.Client{Timeout: 7 * time.Second}
-
-	applyTransportSettings(client, "http://%zz", true)
+func TestAppHTTPClientFactoryIgnoresInvalidProxyAndPreservesTimeout(t *testing.T) {
+	client := newAppHTTPClientFactory("http://%zz").NewClient(7*time.Second, true)
 
 	if client.Timeout != 7*time.Second {
 		t.Fatalf("client timeout = %s, want %s", client.Timeout, 7*time.Second)
@@ -173,38 +184,31 @@ func TestApplyTransportSettingsIgnoresInvalidProxyAndPreservesTimeout(t *testing
 	if !ok {
 		t.Fatalf("client transport = %T, want *http.Transport", client.Transport)
 	}
-	requestURL, err := url.Parse("http://music.example.com/rest/ping")
-	if err != nil {
-		t.Fatal(err)
-	}
 	if transport.Proxy != nil {
-		proxyURL, err := transport.Proxy(&http.Request{URL: requestURL})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if proxyURL != nil {
-			t.Fatalf("proxy URL = %q for invalid proxy configuration, want nil", proxyURL.String())
-		}
+		t.Fatal("transport Proxy is set for an invalid proxy configuration")
 	}
 	if transport.TLSClientConfig == nil || !transport.TLSClientConfig.InsecureSkipVerify {
 		t.Fatal("transport TLSClientConfig.InsecureSkipVerify = false, want true")
 	}
 }
 
-func TestApplyTransportSettingsDoesNotSetTLSConfigWhenSkipSSLVerifyDisabled(t *testing.T) {
-	client := &http.Client{}
-	client.Transport = &http.Transport{TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12}}
+func TestAppHTTPClientFactoryPreservesExistingTransportWithoutProxyConfiguration(t *testing.T) {
+	existing := &http.Transport{TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12}}
+	client := &http.Client{Transport: existing}
 
-	applyTransportSettings(client, "", false)
+	newAppHTTPClientFactory("").configureHTTPClient(client, false)
 
 	transport, ok := client.Transport.(*http.Transport)
 	if !ok {
 		t.Fatalf("client transport = %T, want *http.Transport", client.Transport)
 	}
-	if transport.Proxy != nil {
-		t.Fatal("transport Proxy is set without a proxy URL, want nil")
+	if transport == existing {
+		t.Fatal("transport was reused, want cloned transport")
 	}
-	if transport.TLSClientConfig == nil {
+	if transport.Proxy != nil {
+		t.Fatal("transport Proxy is set without a configured proxy")
+	}
+	if transport.TLSClientConfig == nil || transport.TLSClientConfig.MinVersion != tls.VersionTLS12 {
 		t.Fatal("transport TLSClientConfig was not preserved from original transport")
 	}
 	if transport.TLSClientConfig.InsecureSkipVerify {
@@ -212,14 +216,14 @@ func TestApplyTransportSettingsDoesNotSetTLSConfigWhenSkipSSLVerifyDisabled(t *t
 	}
 }
 
-func TestApplyTransportSettingsClonesExistingTransport(t *testing.T) {
+func TestAppHTTPClientFactoryClonesExistingTransport(t *testing.T) {
 	existing := &http.Transport{
 		MaxIdleConns:        42,
 		MaxIdleConnsPerHost: 7,
 	}
 	client := &http.Client{Transport: existing}
 
-	applyTransportSettings(client, "http://proxy.example.com:8080", true)
+	newAppHTTPClientFactory("http://proxy.example.com:8080").configureHTTPClient(client, true)
 
 	transport, ok := client.Transport.(*http.Transport)
 	if !ok {
@@ -236,5 +240,44 @@ func TestApplyTransportSettingsClonesExistingTransport(t *testing.T) {
 	}
 	if transport.TLSClientConfig == nil || !transport.TLSClientConfig.InsecureSkipVerify {
 		t.Fatal("transport TLSClientConfig.InsecureSkipVerify = false, want true")
+	}
+}
+
+func TestAppHTTPClientFactoryRoutesThroughConfiguredProxy(t *testing.T) {
+	var requestedURL string
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedURL = r.URL.String()
+		_, _ = io.WriteString(w, "proxied")
+	}))
+	defer proxy.Close()
+
+	client := newAppHTTPClientFactory(proxy.URL).NewClient(time.Second, false)
+	resp, err := client.Get("http://music.example.test/stream")
+	if err != nil {
+		t.Fatalf("request through configured proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		t.Fatalf("reading proxy response: %v", err)
+	}
+	if requestedURL != "http://music.example.test/stream" {
+		t.Fatalf("proxy request URL = %q, want music server URL", requestedURL)
+	}
+}
+
+func TestAppHTTPClientFactoryDoesNotMutateDefaultTransport(t *testing.T) {
+	defaultTransport := http.DefaultTransport.(*http.Transport)
+	originalProxy := defaultTransport.Proxy
+	originalTLSConfig := defaultTransport.TLSClientConfig
+
+	client := newAppHTTPClientFactory("http://proxy.example.com:8080").NewClient(time.Second, true)
+	if client.Transport == defaultTransport {
+		t.Fatal("client reused http.DefaultTransport")
+	}
+	if originalProxy != nil && reflect.ValueOf(defaultTransport.Proxy).Pointer() != reflect.ValueOf(originalProxy).Pointer() {
+		t.Fatal("http.DefaultTransport Proxy was modified")
+	}
+	if defaultTransport.TLSClientConfig != originalTLSConfig {
+		t.Fatal("http.DefaultTransport TLSClientConfig was modified")
 	}
 }

--- a/backend/servermanager_test.go
+++ b/backend/servermanager_test.go
@@ -94,11 +94,30 @@ func TestAppHTTPClientFactorySkipSSLOnly(t *testing.T) {
 }
 
 func TestAppHTTPClientFactoryInvalidProxy(t *testing.T) {
-	testNewHTTPClient(t, newHTTPClientTestCase{
-		timeout:     3 * time.Second,
-		proxy:       "http://%zz",
-		wantSkipSSL: false,
-	})
+	factory := newAppHTTPClientFactory("https://proxy.example.com:8080")
+	if factory.configuredProxyErr == nil {
+		t.Fatal("invalid HTTPS proxy configuration was not recorded")
+	}
+	client := factory.NewClient(3*time.Second, false)
+	transport := client.Transport.(*http.Transport)
+	if transport.Proxy != nil {
+		t.Fatal("invalid configured proxy must disable environment proxy fallback")
+	}
+}
+
+func TestParseHTTPProxyURLRejectsMalformedPort(t *testing.T) {
+	for _, rawProxy := range []string{
+		"http://proxy.example.com:0",
+		"http://proxy.example.com:65536",
+		"http://proxy.example.com:not-a-port",
+		"http://proxy.example.com:",
+	} {
+		t.Run(rawProxy, func(t *testing.T) {
+			if _, err := parseHTTPProxyURL(rawProxy); err == nil {
+				t.Fatalf("parseHTTPProxyURL(%q) accepted malformed port", rawProxy)
+			}
+		})
+	}
 }
 
 func TestAppHTTPClientFactoryUsesEnvironmentProxyWithoutConfiguration(t *testing.T) {

--- a/backend/updatechecker.go
+++ b/backend/updatechecker.go
@@ -18,13 +18,15 @@ type UpdateChecker struct {
 	latestReleaseURL string
 	appVersionTag    string
 	lastCheckedTag   *string
+	httpClient       *http.Client
 }
 
-func NewUpdateChecker(appVersionTag, latestReleaseURL string, lastCheckedTag *string) UpdateChecker {
+func NewUpdateChecker(appVersionTag, latestReleaseURL string, lastCheckedTag *string, httpClient *http.Client) UpdateChecker {
 	return UpdateChecker{
 		appVersionTag:    appVersionTag,
 		latestReleaseURL: latestReleaseURL,
 		lastCheckedTag:   lastCheckedTag,
+		httpClient:       httpClient,
 	}
 }
 
@@ -66,11 +68,12 @@ func (u *UpdateChecker) checkForUpdate() {
 }
 
 func (u *UpdateChecker) CheckLatestVersionTag() string {
-	resp, err := http.Head(u.latestReleaseURL)
+	resp, err := u.httpClient.Head(u.latestReleaseURL)
 	if err != nil {
 		log.Printf("failed to check for newest version: %s", err.Error())
 		return ""
 	}
+	defer resp.Body.Close()
 	url := resp.Request.URL.String()
 	url = strings.TrimSuffix(url, "/")
 	idx := strings.LastIndex(url, "/")

--- a/backend/updatechecker.go
+++ b/backend/updatechecker.go
@@ -59,7 +59,7 @@ func (u *UpdateChecker) LatestReleaseURL() *url.URL {
 
 func (u *UpdateChecker) checkForUpdate() {
 	t := u.CheckLatestVersionTag()
-	if t != "" && t != *u.lastCheckedTag {
+	if t != "" && (u.lastCheckedTag == nil || t != *u.lastCheckedTag) {
 		u.versionTagFound = t
 		if u.OnUpdatedVersionFound != nil {
 			u.OnUpdatedVersionFound()
@@ -68,6 +68,9 @@ func (u *UpdateChecker) checkForUpdate() {
 }
 
 func (u *UpdateChecker) CheckLatestVersionTag() string {
+	if u.httpClient == nil || u.latestReleaseURL == "" {
+		return ""
+	}
 	resp, err := u.httpClient.Head(u.latestReleaseURL)
 	if err != nil {
 		log.Printf("failed to check for newest version: %s", err.Error())

--- a/backend/util/util.go
+++ b/backend/util/util.go
@@ -24,6 +24,27 @@ func CopyFile(srcPath, dstPath string) error {
 	return err
 }
 
+func CopyFileWithMode(srcPath, dstPath string, mode os.FileMode) error {
+	fin, err := os.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	defer fin.Close()
+	fout, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	if err := fout.Chmod(mode); err != nil {
+		_ = fout.Close()
+		return err
+	}
+	if _, err := io.Copy(fout, fin); err != nil {
+		_ = fout.Close()
+		return err
+	}
+	return fout.Close()
+}
+
 func GetLocalIP() (string, error) {
 	interfaces, err := net.Interfaces()
 	if err != nil {

--- a/sharedutil/sharedutil.go
+++ b/sharedutil/sharedutil.go
@@ -148,7 +148,7 @@ func ReorderItems[T any](items []T, idxToMove []int, insertIdx int) []T {
 // DownloadFileWithContext downloads a file from the specified URL and saves it to destPath.
 // It respects the provided context and will cancel the request and cleanup if context is done.
 // Returns an error if an error other than cancellation occurs, and returns true IFF the file was completely downloaded.
-func DownloadFileWithContext(ctx context.Context, url string, destPath string) (bool, error) {
+func DownloadFileWithContext(ctx context.Context, client *http.Client, url string, destPath string) (bool, error) {
 	// Create HTTP request with context
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -156,7 +156,7 @@ func DownloadFileWithContext(ctx context.Context, url string, destPath string) (
 	}
 
 	// Perform the request
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return false, fmt.Errorf("performing request: %w", err)
 	}

--- a/sharedutil/sharedutil_test.go
+++ b/sharedutil/sharedutil_test.go
@@ -1,7 +1,12 @@
 package sharedutil
 
 import (
+	"context"
+	"io"
+	"net/http"
+	"os"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/supersonic-app/supersonic/backend/mediaprovider"
@@ -53,4 +58,43 @@ func tracklistsEqual(t *testing.T, a, b []*mediaprovider.Track) bool {
 	return slices.EqualFunc(a, b, func(a, b *mediaprovider.Track) bool {
 		return a.ID == b.ID
 	})
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestDownloadFileWithContextUsesProvidedClient(t *testing.T) {
+	var requested bool
+	client := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		requested = req.URL.String() == "http://music.example.test/track"
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       io.NopCloser(strings.NewReader("audio")),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})}
+
+	destination := t.TempDir() + "/track"
+	completed, err := DownloadFileWithContext(context.Background(), client, "http://music.example.test/track", destination)
+	if err != nil {
+		t.Fatalf("downloading file: %v", err)
+	}
+	if !completed {
+		t.Fatal("download did not complete")
+	}
+	if !requested {
+		t.Fatal("provided HTTP client did not receive the request")
+	}
+	content, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatalf("reading downloaded file: %v", err)
+	}
+	if string(content) != "audio" {
+		t.Fatalf("downloaded content = %q, want %q", content, "audio")
+	}
 }

--- a/ui/controller/controller.go
+++ b/ui/controller/controller.go
@@ -515,6 +515,7 @@ func (c *Controller) downloadTrack(track *mediaprovider.Track, filePath string) 
 		log.Println(err)
 		return
 	}
+	defer reader.Close()
 
 	file, err := os.Create(filePath)
 	if err != nil {
@@ -553,21 +554,25 @@ func (c *Controller) downloadTracks(tracks []*mediaprovider.Track, filePath, dow
 			continue
 		}
 
-		fileName := filepath.Base(track.FilePath)
+		func() {
+			defer reader.Close()
 
-		fileWriter, err := zipWriter.Create(fileName)
-		if err != nil {
-			log.Println(err)
-			continue
-		}
+			fileName := filepath.Base(track.FilePath)
 
-		_, err = io.Copy(fileWriter, reader)
-		if err != nil {
-			log.Println(err)
-			continue
-		}
+			fileWriter, err := zipWriter.Create(fileName)
+			if err != nil {
+				log.Println(err)
+				return
+			}
 
-		log.Printf("Saved song %s to: %s\n", track.Title, filePath)
+			_, err = io.Copy(fileWriter, reader)
+			if err != nil {
+				log.Println(err)
+				return
+			}
+
+			log.Printf("Saved song %s to: %s\n", track.Title, filePath)
+		}()
 	}
 
 	fyne.Do(func() {


### PR DESCRIPTION
## Description

Add one application-level HTTP proxy setting and apply it consistently to Supersonic's outbound internet traffic.

## Problem

MPV playback, Subsonic/Jellyfin API clients, LrcLib, AutoEQ, update checks, Jellyfin track downloads, audio pre-caching, and DLNA music-server forwarding previously used different HTTP client paths. Configuring a proxy for only MPV and the server API left several requests bypassing it.

## Fix

- Add `HTTPProxy` to `[Application]`.
- Use one application HTTP-client factory for outbound Go HTTP traffic.
- Preserve `ProxyFromEnvironment` when no app proxy is configured.
- Give the configured proxy precedence over environment proxies.
- Preserve per-server timeout and TLS-skip settings without mutating `http.DefaultTransport`.
- Pass the proxy to MPV playback.
- Route LrcLib, AutoEQ, update checks, audio pre-caching, Jellyfin downloads, and DLNA music-server forwarding through injected clients.
- Keep IPC and DLNA renderer-control traffic direct because those are local-network control paths, not outbound music-server traffic.
- Redact proxy credentials in logs.

HTTP/HTTPS proxies are supported; SOCKS5 is not included.

## Testing

- `go test ./...` passes: 43 tests across 27 packages.
- macOS packaging succeeds.
- Manual test with `[Application].HTTPProxy = "http://192.168.20.1:7890"` confirmed server/API requests, images, MPV playback, LrcLib lyrics, AutoEQ profile loading, and playback pre-caching work.
- Tests cover proxy routing, environment fallback, invalid proxy handling, cloned transports, TLS behavior, default transport immutability, injected downloads, Jellyfin downloads, and DLNA proxy isolation.