### PR TITLE
Complete Jukebox playback support (continues #300)

### DIFF
--- a/backend/mediaprovider/mediaprovider.go
+++ b/backend/mediaprovider/mediaprovider.go
@@ -330,6 +330,14 @@ type JukeboxProvider interface {
 
 	// Sets the volume of the jukebox player (0-100)
 	JukeboxSetVolume(vol int) error
+
+	// JukeboxSupported reports whether the connected server actually
+	// supports jukebox playback for the current user. Servers exposing a
+	// Subsonic-compatible API don't universally support (or allow per-user)
+	// jukebox mode, and the Subsonic API has no capability-negotiation
+	// mechanism for it, so implementations must determine this by probing
+	// the server (typically once, with the result cached for the session).
+	JukeboxSupported() bool
 }
 
 type JukeboxStatus struct {

--- a/backend/mediaprovider/subsonic/jukebox.go
+++ b/backend/mediaprovider/subsonic/jukebox.go
@@ -2,6 +2,7 @@ package subsonic
 
 import (
 	"fmt"
+	"log"
 	"strconv"
 
 	"github.com/supersonic-app/supersonic/backend/mediaprovider"
@@ -78,6 +79,9 @@ func (s *subsonicMediaProvider) JukeboxSupported() bool {
 	s.jukeboxSupportOnce.Do(func() {
 		_, err := s.client.JukeboxControl("status", nil)
 		s.jukeboxSupported = err == nil
+		if err != nil {
+			log.Printf("jukebox: server does not support jukebox playback (or it's not permitted for this user): %v", err)
+		}
 	})
 	return s.jukeboxSupported
 }

--- a/backend/mediaprovider/subsonic/jukebox.go
+++ b/backend/mediaprovider/subsonic/jukebox.go
@@ -67,3 +67,17 @@ func (s *subsonicMediaProvider) JukeboxGetStatus() (*mediaprovider.JukeboxStatus
 		PositionSeconds: float64(stat.Position),
 	}, nil
 }
+
+// JukeboxSupported probes the server once (a side-effect-free "status" call)
+// and caches the result for the lifetime of this provider. The Subsonic API
+// doesn't advertise jukebox support via getOpenSubsonicExtensions or
+// elsewhere, and not every server allows it (it may be disabled globally, or
+// per-user via Settings > Users > Jukebox Role), so the only reliable way to
+// know is to try it.
+func (s *subsonicMediaProvider) JukeboxSupported() bool {
+	s.jukeboxSupportOnce.Do(func() {
+		_, err := s.client.JukeboxControl("status", nil)
+		s.jukeboxSupported = err == nil
+	})
+	return s.jukeboxSupported
+}

--- a/backend/mediaprovider/subsonic/subsonicmediaprovider.go
+++ b/backend/mediaprovider/subsonic/subsonicmediaprovider.go
@@ -40,6 +40,9 @@ type subsonicMediaProvider struct {
 
 	playbackReportOnce      sync.Once
 	playbackReportSupported bool
+
+	jukeboxSupportOnce sync.Once
+	jukeboxSupported   bool
 }
 
 func SubsonicMediaProvider(subsonicClient *subsonic.Client) mediaprovider.MediaProvider {

--- a/backend/playbackengine.go
+++ b/backend/playbackengine.go
@@ -1204,11 +1204,15 @@ func (p *playbackEngine) handleTimePosUpdate(seeked bool) {
 	isNearEnd := meta.Type != mediaprovider.MediaItemTypeRadioStation && s.TimePos > meta.Duration.Seconds()-10
 	if p.needToSetNextTrack && isNearEnd {
 		p.needToSetNextTrack = false
+		var err error
 		if nextIdx := p.nextPlayingIndex(); nextIdx >= 0 && nextIdx < len(p.playQueue) {
-			p.setNextTrack(nextIdx)
+			err = p.setNextTrack(nextIdx)
 		} else {
 			// no next track to play, ensure player knows this
-			p.setNextTrack(-1)
+			err = p.setNextTrack(-1)
+		}
+		if err != nil {
+			log.Printf("failed to set next track: %v", err)
 		}
 	}
 	if p.callbacksDisabled {

--- a/backend/playbackmanager.go
+++ b/backend/playbackmanager.go
@@ -68,6 +68,11 @@ type RemotePlaybackDevice struct {
 	new      func() (player.BasePlayer, error)
 }
 
+// JukeboxProtocol is the RemotePlaybackDevice.Protocol value for server-side
+// Jukebox playback, so callers (e.g. the UI cast menu) can special-case it
+// without depending on the device Name string.
+const JukeboxProtocol = "Jukebox"
+
 // jukeboxDeviceURL identifies the RemotePlaybackDevice for server-side Jukebox
 // playback. Unlike DLNA devices (identified by their real network URL), the
 // Jukebox device isn't discovered on the network - it's synthesized from the
@@ -297,7 +302,7 @@ func (p *PlaybackManager) RemotePlayers() []RemotePlaybackDevice {
 		players = append(players, RemotePlaybackDevice{
 			Name:     "Jukebox",
 			URL:      jukeboxDeviceURL,
-			Protocol: "Jukebox",
+			Protocol: JukeboxProtocol,
 			new: func() (player.BasePlayer, error) {
 				return jukebox.NewJukeboxPlayer(jp)
 			},

--- a/backend/playbackmanager.go
+++ b/backend/playbackmanager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/supersonic-app/supersonic/backend/mediaprovider"
 	"github.com/supersonic-app/supersonic/backend/player"
 	"github.com/supersonic-app/supersonic/backend/player/dlna"
+	"github.com/supersonic-app/supersonic/backend/player/jukebox"
 	"github.com/supersonic-app/supersonic/backend/player/mpv"
 	"github.com/supersonic-app/supersonic/sharedutil"
 )
@@ -66,6 +67,13 @@ type RemotePlaybackDevice struct {
 	Protocol string
 	new      func() (player.BasePlayer, error)
 }
+
+// jukeboxDeviceURL identifies the RemotePlaybackDevice for server-side Jukebox
+// playback. Unlike DLNA devices (identified by their real network URL), the
+// Jukebox device isn't discovered on the network - it's synthesized from the
+// currently connected server's capabilities - so it needs a stable placeholder
+// URL to be identifiable/comparable in the cast device list.
+const jukeboxDeviceURL = "jukebox://current-server"
 
 func NewPlaybackManager(
 	ctx context.Context,
@@ -275,11 +283,38 @@ func (p *PlaybackManager) scanRemotePlayers(ctx context.Context, waitSec int) {
 	p.remotePlayersLock.Unlock()
 }
 
+// RemotePlayers returns the list of currently available remote (cast)
+// playback devices: network-discovered DLNA renderers, plus a Jukebox device
+// if the connected server supports server-side Jukebox playback.
 func (p *PlaybackManager) RemotePlayers() []RemotePlaybackDevice {
 	p.remotePlayersLock.Lock()
-	players := p.remotePlayers
+	discovered := p.remotePlayers
 	p.remotePlayersLock.Unlock()
+
+	players := make([]RemotePlaybackDevice, 0, len(discovered)+1)
+	players = append(players, discovered...)
+	if jp, ok := p.jukeboxProvider(); ok {
+		players = append(players, RemotePlaybackDevice{
+			Name:     "Jukebox",
+			URL:      jukeboxDeviceURL,
+			Protocol: "Jukebox",
+			new: func() (player.BasePlayer, error) {
+				return jukebox.NewJukeboxPlayer(jp)
+			},
+		})
+	}
 	return players
+}
+
+// jukeboxProvider returns the connected server's mediaprovider.JukeboxProvider
+// capability, if it has one.
+func (p *PlaybackManager) jukeboxProvider() (mediaprovider.JukeboxProvider, bool) {
+	mp := p.engine.sm.GetServer()
+	if mp == nil {
+		return nil, false
+	}
+	jp, ok := mp.(mediaprovider.JukeboxProvider)
+	return jp, ok
 }
 
 func (p *PlaybackManager) CurrentRemotePlayer() *RemotePlaybackDevice {

--- a/backend/playbackmanager.go
+++ b/backend/playbackmanager.go
@@ -43,6 +43,14 @@ type PlaybackManager struct {
 	remotePlayers       []RemotePlaybackDevice
 	currentRemotePlayer *RemotePlaybackDevice
 
+	// jukeboxSupported caches whether the connected server has confirmed
+	// support for Jukebox playback (see refreshJukeboxSupport). Only ever
+	// written from a background goroutine kicked off on server (re)connect,
+	// so that RemotePlayers() - called synchronously from the UI - never
+	// blocks on the network probe itself.
+	jukeboxSupportedLock sync.Mutex
+	jukeboxSupported     bool
+
 	onWaveformImgUpdate []func(*WaveformImage)
 	onPlayerChange      []func()
 
@@ -104,6 +112,13 @@ func NewPlaybackManager(
 		pm.wfmGen = NewWaveformImageGenerator(c)
 	}
 	pm.addOnTrackChangeHook()
+	s.OnServerConnected(func(*ServerConfig) {
+		pm.setJukeboxSupported(false)
+		go pm.refreshJukeboxSupport()
+	})
+	s.OnLogout(func() {
+		pm.setJukeboxSupported(false)
+	})
 	go pm.runCmdQueue(ctx)
 	return pm
 }
@@ -298,7 +313,7 @@ func (p *PlaybackManager) RemotePlayers() []RemotePlaybackDevice {
 
 	players := make([]RemotePlaybackDevice, 0, len(discovered)+1)
 	players = append(players, discovered...)
-	if jp, ok := p.jukeboxProvider(); ok {
+	if jp, ok := p.jukeboxProvider(); ok && p.isJukeboxSupported() {
 		players = append(players, RemotePlaybackDevice{
 			Name:     "Jukebox",
 			URL:      jukeboxDeviceURL,
@@ -312,7 +327,9 @@ func (p *PlaybackManager) RemotePlayers() []RemotePlaybackDevice {
 }
 
 // jukeboxProvider returns the connected server's mediaprovider.JukeboxProvider
-// capability, if it has one.
+// capability, if it has one. This is a cheap type assertion - it says nothing
+// about whether the server actually allows jukebox playback for this user;
+// see isJukeboxSupported/refreshJukeboxSupport for that.
 func (p *PlaybackManager) jukeboxProvider() (mediaprovider.JukeboxProvider, bool) {
 	mp := p.engine.sm.GetServer()
 	if mp == nil {
@@ -320,6 +337,28 @@ func (p *PlaybackManager) jukeboxProvider() (mediaprovider.JukeboxProvider, bool
 	}
 	jp, ok := mp.(mediaprovider.JukeboxProvider)
 	return jp, ok
+}
+
+func (p *PlaybackManager) isJukeboxSupported() bool {
+	p.jukeboxSupportedLock.Lock()
+	defer p.jukeboxSupportedLock.Unlock()
+	return p.jukeboxSupported
+}
+
+func (p *PlaybackManager) setJukeboxSupported(supported bool) {
+	p.jukeboxSupportedLock.Lock()
+	p.jukeboxSupported = supported
+	p.jukeboxSupportedLock.Unlock()
+}
+
+// refreshJukeboxSupport probes (via mediaprovider.JukeboxProvider.JukeboxSupported,
+// which may block on a network call) whether the connected server actually
+// allows jukebox playback, and caches the result for RemotePlayers() to
+// consult. Must only be called from a background goroutine - never from a
+// path that can be reached synchronously from the UI.
+func (p *PlaybackManager) refreshJukeboxSupport() {
+	jp, ok := p.jukeboxProvider()
+	p.setJukeboxSupported(ok && jp.JukeboxSupported())
 }
 
 func (p *PlaybackManager) CurrentRemotePlayer() *RemotePlaybackDevice {

--- a/backend/player/common/remoteplayerutils.go
+++ b/backend/player/common/remoteplayerutils.go
@@ -1,0 +1,66 @@
+package common
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+type TrackChangeTimer struct {
+	timerActive atomic.Bool
+	timer       *time.Timer
+	resetChan   chan (time.Duration)
+
+	onHandleTrackChange func()
+}
+
+func NewTrackChangeTimer(onHandleTrackChange func()) TrackChangeTimer {
+	return TrackChangeTimer{
+		resetChan:           make(chan time.Duration),
+		onHandleTrackChange: onHandleTrackChange,
+	}
+}
+
+func (d *TrackChangeTimer) Reset(dur time.Duration) {
+	if d.timerActive.Swap(true) {
+		// was active
+		d.resetChan <- dur
+		return
+	}
+	if dur == 0 {
+		d.timerActive.Store(false)
+		return
+	}
+
+	d.timer = time.NewTimer(dur)
+	go func() {
+		for {
+			select {
+			case dur := <-d.resetChan:
+				if dur == 0 {
+					d.timerActive.Store(false)
+					if !d.timer.Stop() {
+						select {
+						case <-d.timer.C:
+						default:
+						}
+					}
+					d.timer = nil
+					return
+				}
+				// reset the timer
+				if !d.timer.Stop() {
+					select {
+					case <-d.timer.C:
+					default:
+					}
+				}
+				d.timer.Reset(dur)
+			case <-d.timer.C:
+				d.timerActive.Store(false)
+				d.timer = nil
+				d.onHandleTrackChange()
+				return
+			}
+		}
+	}()
+}

--- a/backend/player/common/remoteplayerutils.go
+++ b/backend/player/common/remoteplayerutils.go
@@ -1,66 +1,48 @@
 package common
 
 import (
-	"sync/atomic"
+	"sync"
 	"time"
 )
 
+// TrackChangeTimer is a resettable one-shot timer used by remote player
+// implementations (DLNAPlayer, JukeboxPlayer) to estimate when the current
+// track will end, since neither DLNA nor the Subsonic jukebox API pushes
+// playback events to the client.
+//
+// Reset is safe to call concurrently from multiple goroutines (e.g. a
+// user-initiated Stop() racing a delayed background position-sync), which a
+// previous implementation based on an unbuffered channel handoff was not:
+// two concurrent Reset calls could race such that one delivers a "cancel"
+// message that causes the timer's dispatcher goroutine to exit while a
+// second, already in-flight send is still waiting for a receiver, blocking
+// that caller (and anything serialized behind it, such as the playback
+// command queue) forever.
 type TrackChangeTimer struct {
-	timerActive atomic.Bool
-	timer       *time.Timer
-	resetChan   chan (time.Duration)
+	mu    sync.Mutex
+	timer *time.Timer
 
 	onHandleTrackChange func()
 }
 
 func NewTrackChangeTimer(onHandleTrackChange func()) TrackChangeTimer {
-	return TrackChangeTimer{
-		resetChan:           make(chan time.Duration),
-		onHandleTrackChange: onHandleTrackChange,
-	}
+	return TrackChangeTimer{onHandleTrackChange: onHandleTrackChange}
 }
 
+// Reset (re)arms the timer to fire onHandleTrackChange after dur, replacing
+// any previously scheduled fire. A dur of exactly 0 cancels any pending fire
+// without scheduling a new one; a negative dur fires (almost) immediately,
+// same as a plain time.Timer.
 func (d *TrackChangeTimer) Reset(dur time.Duration) {
-	if d.timerActive.Swap(true) {
-		// was active
-		d.resetChan <- dur
-		return
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.timer != nil {
+		d.timer.Stop()
+		d.timer = nil
 	}
 	if dur == 0 {
-		d.timerActive.Store(false)
 		return
 	}
-
-	d.timer = time.NewTimer(dur)
-	go func() {
-		for {
-			select {
-			case dur := <-d.resetChan:
-				if dur == 0 {
-					d.timerActive.Store(false)
-					if !d.timer.Stop() {
-						select {
-						case <-d.timer.C:
-						default:
-						}
-					}
-					d.timer = nil
-					return
-				}
-				// reset the timer
-				if !d.timer.Stop() {
-					select {
-					case <-d.timer.C:
-					default:
-					}
-				}
-				d.timer.Reset(dur)
-			case <-d.timer.C:
-				d.timerActive.Store(false)
-				d.timer = nil
-				d.onHandleTrackChange()
-				return
-			}
-		}
-	}()
+	d.timer = time.AfterFunc(dur, d.onHandleTrackChange)
 }

--- a/backend/player/common/remoteplayerutils_test.go
+++ b/backend/player/common/remoteplayerutils_test.go
@@ -1,0 +1,76 @@
+package common
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestTrackChangeTimer_ConcurrentReset reproduces the scenario that used to
+// deadlock: many goroutines calling Reset(0) (cancel, e.g. from Stop/Pause)
+// concurrently with others calling Reset(nonzero) (re-arm, e.g. from a
+// delayed background position sync). With the old unbuffered-channel-based
+// implementation, a Reset(0) landing first could cause the timer's
+// dispatcher goroutine to exit while a concurrent Reset(nonzero) call was
+// still blocked sending to it, hanging that caller (and anything serialized
+// behind it) forever.
+func TestTrackChangeTimer_ConcurrentReset(t *testing.T) {
+	timer := NewTrackChangeTimer(func() {})
+	timer.Reset(50 * time.Millisecond)
+
+	const n = 100
+	var wg sync.WaitGroup
+	wg.Add(2 * n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			timer.Reset(0)
+		}()
+		go func() {
+			defer wg.Done()
+			timer.Reset(10 * time.Millisecond)
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// all Reset calls returned - no deadlock
+	case <-time.After(5 * time.Second):
+		t.Fatal("Reset calls did not return in time - possible deadlock")
+	}
+}
+
+// TestTrackChangeTimer_FiresAndCancels checks the basic contract: a
+// scheduled fire actually invokes the callback, and Reset(0) suppresses a
+// fire that hasn't happened yet.
+func TestTrackChangeTimer_FiresAndCancels(t *testing.T) {
+	fired := make(chan struct{}, 1)
+	timer := NewTrackChangeTimer(func() {
+		select {
+		case fired <- struct{}{}:
+		default:
+		}
+	})
+
+	timer.Reset(20 * time.Millisecond)
+	select {
+	case <-fired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("callback did not fire")
+	}
+
+	timer.Reset(50 * time.Millisecond)
+	timer.Reset(0)
+	select {
+	case <-fired:
+		t.Fatal("callback fired after being cancelled")
+	case <-time.After(150 * time.Millisecond):
+		// expected: no fire
+	}
+}

--- a/backend/player/dlna/dlnaplayer.go
+++ b/backend/player/dlna/dlnaplayer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/supersonic-app/go-upnpcast/services/renderingcontrol"
 	"github.com/supersonic-app/supersonic/backend/mediaprovider"
 	"github.com/supersonic-app/supersonic/backend/player"
+	"github.com/supersonic-app/supersonic/backend/player/common"
 	"github.com/supersonic-app/supersonic/backend/util"
 )
 
@@ -90,9 +91,7 @@ type DLNAPlayer struct {
 	failedToSetNext    bool
 	unsetNextMediaItem *avtransport.MediaItem
 
-	timerActive atomic.Bool
-	timer       *time.Timer
-	resetChan   chan (time.Duration)
+	trackChangeTimer common.TrackChangeTimer
 }
 
 func NewDLNAPlayer(device *device.MediaRenderer, coverArtPathFn func(coverArtID string) (string, error)) (*DLNAPlayer, error) {
@@ -120,12 +119,14 @@ func NewDLNAPlayer(device *device.MediaRenderer, coverArtPathFn func(coverArtID 
 		return nil, fmt.Errorf("failed to connect to %s", device.FriendlyName)
 	}
 
-	return &DLNAPlayer{
+	d := &DLNAPlayer{
 		avTransport:    avt,
 		renderControl:  rc,
-		resetChan:      make(chan time.Duration),
 		coverArtPathFn: coverArtPathFn,
-	}, nil
+	}
+	d.trackChangeTimer = common.NewTrackChangeTimer(d.handleOnTrackChange)
+
+	return d, nil
 }
 
 // buildMediaItem assembles the avtransport.MediaItem for a track. It
@@ -219,7 +220,7 @@ func (d *DLNAPlayer) PlayFile(urlstr string, meta mediaprovider.MediaItemMetadat
 	}
 	d.state = playing
 	remainingDur := meta.Duration - time.Duration(startTime)*time.Second
-	d.setTrackChangeTimer(remainingDur)
+	d.trackChangeTimer.Reset(remainingDur)
 	d.stopwatch.Reset()
 	d.stopwatch.Start()
 	d.lastStartTime = int(startTime)
@@ -304,7 +305,7 @@ func (d *DLNAPlayer) Continue() error {
 	nextTrackChange := d.curTrackMeta.Duration - d.curPlayPos()
 	d.metaLock.Unlock()
 	d.state = playing
-	d.setTrackChangeTimer(nextTrackChange)
+	d.trackChangeTimer.Reset(nextTrackChange)
 	d.stopwatch.Start()
 	d.InvokeOnPlaying()
 	return nil
@@ -321,7 +322,7 @@ func (d *DLNAPlayer) Pause() error {
 	if err := d.avTransport.Pause(ctx); err != nil {
 		return err
 	}
-	d.setTrackChangeTimer(0)
+	d.trackChangeTimer.Reset(0)
 	d.stopwatch.Stop()
 	d.state = paused
 	d.InvokeOnPaused()
@@ -355,7 +356,7 @@ func (d *DLNAPlayer) Stop(force bool) error {
 		}
 		fallthrough
 	case paused:
-		d.setTrackChangeTimer(0)
+		d.trackChangeTimer.Reset(0)
 		d.stopwatch.Reset()
 		d.lastStartTime = 0
 		d.state = stopped
@@ -387,7 +388,7 @@ func (d *DLNAPlayer) SeekSeconds(secs float64) error {
 		d.metaLock.Lock()
 		nextTrackChange := d.curTrackMeta.Duration - time.Duration(secs)*time.Second
 		d.metaLock.Unlock()
-		d.setTrackChangeTimer(nextTrackChange)
+		d.trackChangeTimer.Reset(nextTrackChange)
 		d.stopwatch.Start()
 	}
 
@@ -443,7 +444,7 @@ func (d *DLNAPlayer) curPlayPos() time.Duration {
 
 func (d *DLNAPlayer) Destroy() {
 	d.destroyed = true
-	d.setTrackChangeTimer(0)
+	d.trackChangeTimer.Reset(0)
 	if d.cancelRequest != nil {
 		d.cancelRequest()
 	}
@@ -464,7 +465,7 @@ func (d *DLNAPlayer) syncPlaybackTime() {
 		if d.state == playing {
 			d.stopwatch.Start()
 		}
-		d.setTrackChangeTimer(d.curTrackMeta.Duration - time.Duration(d.lastStartTime)*time.Second)
+		d.trackChangeTimer.Reset(d.curTrackMeta.Duration - time.Duration(d.lastStartTime)*time.Second)
 		d.InvokeOnSeek()
 	}
 }
@@ -492,51 +493,6 @@ func (d *DLNAPlayer) ensureSetupProxy() error {
 
 	go d.proxyServer.Serve(listener)
 	return nil
-}
-
-func (d *DLNAPlayer) setTrackChangeTimer(dur time.Duration) {
-	if d.timerActive.Swap(true) {
-		// was active
-		d.resetChan <- dur
-		return
-	}
-	if dur == 0 {
-		d.timerActive.Store(false)
-		return
-	}
-
-	d.timer = time.NewTimer(dur)
-	go func() {
-		for {
-			select {
-			case dur := <-d.resetChan:
-				if dur == 0 {
-					d.timerActive.Store(false)
-					if !d.timer.Stop() {
-						select {
-						case <-d.timer.C:
-						default:
-						}
-					}
-					d.timer = nil
-					return
-				}
-				// reset the timer
-				if !d.timer.Stop() {
-					select {
-					case <-d.timer.C:
-					default:
-					}
-				}
-				d.timer.Reset(dur)
-			case <-d.timer.C:
-				d.timerActive.Store(false)
-				d.timer = nil
-				d.handleOnTrackChange()
-				return
-			}
-		}
-	}()
 }
 
 func (d *DLNAPlayer) handleOnTrackChange() {
@@ -569,7 +525,7 @@ func (d *DLNAPlayer) handleOnTrackChange() {
 		d.lastStartTime = 0
 		d.stopwatch.Reset()
 		d.stopwatch.Start()
-		d.setTrackChangeTimer(nextTrackChange)
+		d.trackChangeTimer.Reset(nextTrackChange)
 		d.InvokeOnTrackChange()
 
 		go func() {

--- a/backend/player/jukebox/jukeboxplayer.go
+++ b/backend/player/jukebox/jukeboxplayer.go
@@ -303,8 +303,24 @@ func (j *JukeboxPlayer) handleOnTrackChange() {
 	}
 
 	if !stat.Playing {
-		// the server-side queue is exhausted (or was stopped by another
-		// client) - nothing left to advance to
+		if j.hasNextTrack {
+			// We know a track was queued to play after this one, but the
+			// server hasn't started it yet. Observed with Navidrome: it
+			// spawns a fresh mpv process per track ("Starting trackSwitcher
+			// goroutine" / "Found mpv" in its logs), which isn't
+			// instantaneous, so there's a brief window right at a track
+			// boundary where status legitimately reports not-playing even
+			// though playback is about to continue. Treating that as
+			// "queue exhausted" here would both tell the engine playback
+			// stopped (dropping the UI's now-playing display) and leave
+			// the timer permanently disarmed, since nothing else re-arms
+			// it - silently killing playback of every track after this
+			// one. Check again shortly instead.
+			j.trackChangeTimer.Reset(retryDelay)
+			return
+		}
+		// no next track was queued, so the server has genuinely run out of
+		// queue to advance to (or was stopped by another client)
 		j.state = stopped
 		j.lastStartTime = 0
 		j.stopwatch.Reset()

--- a/backend/player/jukebox/jukeboxplayer.go
+++ b/backend/player/jukebox/jukeboxplayer.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/supersonic-app/supersonic/backend/mediaprovider"
 	"github.com/supersonic-app/supersonic/backend/player"
+	"github.com/supersonic-app/supersonic/backend/player/common"
+	"github.com/supersonic-app/supersonic/backend/util"
 )
 
 const (
@@ -22,11 +24,24 @@ type JukeboxPlayer struct {
 	volume  int
 	seeking bool
 
+	// start playback position in seconds of the last seek/time sync
+	lastStartTime int
+	// how long the track has been playing since last time sync
+	stopwatch util.Stopwatch
+
+	trackChangeTimer common.TrackChangeTimer
+
 	curTrack           int
 	queueLength        int
 	curTrackDuration   float64
 	startTrackTime     float64
 	startedAtUnixMilli int64
+}
+
+func NewJukeboxPlayer(provider mediaprovider.JukeboxProvider) (*JukeboxPlayer, error) {
+	j := &JukeboxPlayer{provider: provider}
+	j.trackChangeTimer = common.NewTrackChangeTimer(j.handleOnTrackChange)
+	return j, nil
 }
 
 func (j *JukeboxPlayer) SetVolume(vol int) error {
@@ -125,20 +140,41 @@ func (j *JukeboxPlayer) IsSeeking() bool {
 
 func (j *JukeboxPlayer) GetStatus() player.Status {
 	state := player.Stopped
-	if j.state == playing {
+	switch j.state {
+	case playing:
 		state = player.Playing
-	} else if j.state == paused {
+	case paused:
 		state = player.Paused
 	}
 
-	// TODO - the rest
-
 	return player.Status{
-		State: state,
+		State:   state,
+		TimePos: j.curPlayPos().Seconds(),
+		//Duration: TODO
 	}
 }
 
+func (j *JukeboxPlayer) curPlayPos() time.Duration {
+	return time.Duration(j.lastStartTime)*time.Second + j.stopwatch.Elapsed()
+}
+
 func (j *JukeboxPlayer) Destroy() {}
+
+func (j *JukeboxPlayer) handleOnTrackChange() {
+	stopping := false
+	// TODO: is playing next track?
+
+	if stopping {
+		j.lastStartTime = 0
+		j.stopwatch.Reset()
+	} else {
+		j.lastStartTime = 0
+		j.stopwatch.Reset()
+		j.stopwatch.Start()
+		j.trackChangeTimer.Reset(0 /*TODO: next track time*/)
+		j.InvokeOnTrackChange()
+	}
+}
 
 func (j *JukeboxPlayer) startAndUpdateTime() error {
 	beforeStart := time.Now()

--- a/backend/player/jukebox/jukeboxplayer.go
+++ b/backend/player/jukebox/jukeboxplayer.go
@@ -1,6 +1,7 @@
 package jukebox
 
 import (
+	"log"
 	"time"
 
 	"github.com/supersonic-app/supersonic/backend/mediaprovider"
@@ -15,10 +16,21 @@ const (
 	paused  = 2
 )
 
+// syncSettleDelay is how long to wait after issuing a command that changes
+// server-side playback (start/seek) before polling JukeboxGetStatus to
+// reconcile our locally-estimated position against the server's authoritative
+// one. Mirrors the equivalent settle delays in DLNAPlayer.
+const syncSettleDelay = 2 * time.Second
+
+// retryDelay is how soon to retry after a failed JukeboxGetStatus call
+// triggered by the track change timer firing.
+const retryDelay = 2 * time.Second
+
 type JukeboxPlayer struct {
 	player.BasePlayerCallbackImpl
 
-	provider mediaprovider.JukeboxProvider
+	provider  mediaprovider.JukeboxProvider
+	destroyed bool
 
 	state   int // stopped, playing, paused
 	volume  int
@@ -31,9 +43,17 @@ type JukeboxPlayer struct {
 
 	trackChangeTimer common.TrackChangeTimer
 
-	curTrack         int
+	// index into the server-side jukebox queue of the currently playing track
+	curTrack int
+	// number of tracks currently in the server-side jukebox queue
 	queueLength      int
 	curTrackDuration float64
+
+	// duration of the track queued via SetNextTrack, used to know the new
+	// track's duration once the server reports it's started playing.
+	// Only meaningful when hasNextTrack is true.
+	hasNextTrack      bool
+	nextTrackDuration float64
 }
 
 func NewJukeboxPlayer(provider mediaprovider.JukeboxProvider) (*JukeboxPlayer, error) {
@@ -43,6 +63,9 @@ func NewJukeboxPlayer(provider mediaprovider.JukeboxProvider) (*JukeboxPlayer, e
 }
 
 func (j *JukeboxPlayer) SetVolume(vol int) error {
+	if j.destroyed {
+		return nil
+	}
 	if err := j.provider.JukeboxSetVolume(vol); err != nil {
 		return err
 	}
@@ -55,7 +78,7 @@ func (j *JukeboxPlayer) GetVolume() int {
 }
 
 func (j *JukeboxPlayer) Continue() error {
-	if j.state == playing {
+	if j.destroyed || j.state == playing {
 		return nil
 	}
 	if err := j.provider.JukeboxStart(); err != nil {
@@ -64,17 +87,21 @@ func (j *JukeboxPlayer) Continue() error {
 
 	j.state = playing
 	j.stopwatch.Start()
+	j.trackChangeTimer.Reset(j.remainingTrackTime())
 	j.InvokeOnPlaying()
+
+	go j.scheduleSync(syncSettleDelay)
 	return nil
 }
 
 func (j *JukeboxPlayer) Pause() error {
-	if j.state != playing {
+	if j.destroyed || j.state != playing {
 		return nil
 	}
 	if err := j.provider.JukeboxStop(); err != nil {
 		return err
 	}
+	j.trackChangeTimer.Reset(0)
 	j.stopwatch.Stop()
 	j.state = paused
 	j.InvokeOnPaused()
@@ -82,12 +109,13 @@ func (j *JukeboxPlayer) Pause() error {
 }
 
 func (j *JukeboxPlayer) Stop(_ bool) error {
-	if j.state == stopped {
+	if j.destroyed || j.state == stopped {
 		return nil
 	}
 	if err := j.provider.JukeboxStop(); err != nil {
 		return err
 	}
+	j.trackChangeTimer.Reset(0)
 	j.state = stopped
 	j.lastStartTime = 0
 	j.stopwatch.Reset()
@@ -96,6 +124,9 @@ func (j *JukeboxPlayer) Stop(_ bool) error {
 }
 
 func (j *JukeboxPlayer) PlayTrack(track *mediaprovider.Track, startTime float64) error {
+	if j.destroyed {
+		return nil
+	}
 	if err := j.provider.JukeboxSet(track.ID); err != nil {
 		return err
 	}
@@ -106,6 +137,7 @@ func (j *JukeboxPlayer) PlayTrack(track *mediaprovider.Track, startTime float64)
 	j.curTrack = 0
 	j.queueLength = 1
 	j.curTrackDuration = track.Duration.Seconds()
+	j.hasNextTrack = false
 
 	if startTime > 0 {
 		if err := j.provider.JukeboxSeek(j.curTrack, int(startTime)); err != nil {
@@ -116,33 +148,66 @@ func (j *JukeboxPlayer) PlayTrack(track *mediaprovider.Track, startTime float64)
 	j.stopwatch.Reset()
 	j.stopwatch.Start()
 	j.state = playing
+	j.trackChangeTimer.Reset(j.remainingTrackTime())
 	j.InvokeOnPlaying()
 
+	go j.scheduleSync(syncSettleDelay)
 	return nil
 }
 
+// SetNextTrack queues track to play after the current one, replacing any
+// previously queued next track. A nil track clears the queued next track,
+// without affecting the currently playing one.
 func (j *JukeboxPlayer) SetNextTrack(track *mediaprovider.Track) error {
+	if j.destroyed {
+		return nil
+	}
+
 	// we need to replace the last track in the queue, remove it first
 	if j.curTrack < j.queueLength-1 {
 		if err := j.provider.JukeboxRemove(j.curTrack + 1); err != nil {
 			return err
 		}
 		j.queueLength -= 1
+		j.hasNextTrack = false
 	}
+
+	if track == nil {
+		return nil
+	}
+
 	// append the new track to the queue
 	if err := j.provider.JukeboxAdd(track.ID); err != nil {
 		return err
 	}
 	j.queueLength += 1
+	j.hasNextTrack = true
+	j.nextTrackDuration = track.Duration.Seconds()
 	return nil
 }
 
 func (j *JukeboxPlayer) SeekSeconds(secs float64) error {
+	if j.destroyed {
+		return nil
+	}
+
 	j.seeking = true
 	err := j.provider.JukeboxSeek(j.curTrack, int(secs))
 	j.seeking = false
+	if err != nil {
+		return err
+	}
+
+	j.lastStartTime = int(secs)
+	j.stopwatch.Reset()
+	if j.state == playing {
+		j.stopwatch.Start()
+	}
+	j.trackChangeTimer.Reset(j.remainingTrackTime())
 	j.InvokeOnSeek()
-	return err
+
+	go j.scheduleSync(syncSettleDelay)
+	return nil
 }
 
 func (j *JukeboxPlayer) IsSeeking() bool {
@@ -169,20 +234,99 @@ func (j *JukeboxPlayer) curPlayPos() time.Duration {
 	return time.Duration(j.lastStartTime)*time.Second + j.stopwatch.Elapsed()
 }
 
-func (j *JukeboxPlayer) Destroy() {}
+// remainingTrackTime is how long until the current track is expected to end,
+// based on our local bookkeeping of its duration and current position
+// (including time elapsed since the last seek/time sync, not just the
+// position as of then).
+func (j *JukeboxPlayer) remainingTrackTime() time.Duration {
+	return time.Duration(j.curTrackDuration*float64(time.Second)) - j.curPlayPos()
+}
 
+func (j *JukeboxPlayer) Destroy() {
+	j.destroyed = true
+	j.trackChangeTimer.Reset(0)
+}
+
+// handleOnTrackChange fires when the local trackChangeTimer estimates the
+// current track has finished. Since the server-side jukebox doesn't push
+// playback events, this always reconciles against the server's authoritative
+// JukeboxGetStatus before updating any state.
 func (j *JukeboxPlayer) handleOnTrackChange() {
-	stopping := false
-	// TODO: is playing next track?
-
-	if stopping {
-		j.lastStartTime = 0
-		j.stopwatch.Reset()
-	} else {
-		j.lastStartTime = 0
-		j.stopwatch.Reset()
-		j.stopwatch.Start()
-		j.trackChangeTimer.Reset(0 /*TODO: next track time*/)
-		j.InvokeOnTrackChange()
+	if j.destroyed {
+		return
 	}
+
+	stat, err := j.provider.JukeboxGetStatus()
+	if err != nil {
+		log.Printf("jukebox: failed to get status: %v", err)
+		if !j.destroyed {
+			j.trackChangeTimer.Reset(retryDelay)
+		}
+		return
+	}
+
+	if !stat.Playing {
+		// the server-side queue is exhausted (or was stopped by another
+		// client) - nothing left to advance to
+		j.state = stopped
+		j.lastStartTime = 0
+		j.stopwatch.Reset()
+		j.InvokeOnStopped()
+		return
+	}
+
+	if stat.CurrentTrack == j.curTrack {
+		// our local timer fired early due to clock drift - the server
+		// hasn't advanced tracks yet. Resync and re-arm for the
+		// remaining time rather than treating this as a track change.
+		j.resyncFromStatus(stat)
+		return
+	}
+
+	// the server has advanced to the next track in the queue
+	j.curTrack = stat.CurrentTrack
+	if j.hasNextTrack {
+		j.curTrackDuration = j.nextTrackDuration
+		j.hasNextTrack = false
+	}
+	j.lastStartTime = int(stat.PositionSeconds)
+	j.stopwatch.Reset()
+	j.stopwatch.Start()
+	j.trackChangeTimer.Reset(j.remainingTrackTime())
+	j.InvokeOnTrackChange()
+}
+
+// scheduleSync waits the given delay and then reconciles local playback
+// position/state against the server's authoritative JukeboxGetStatus. Used
+// after commands (start/seek) that change server-side playback, to correct
+// for network round-trip latency and any drift in the local estimate.
+func (j *JukeboxPlayer) scheduleSync(delay time.Duration) {
+	time.Sleep(delay)
+	if j.destroyed {
+		return
+	}
+	stat, err := j.provider.JukeboxGetStatus()
+	if err != nil {
+		log.Printf("jukebox: failed to sync status: %v", err)
+		return
+	}
+	if j.destroyed || stat.CurrentTrack != j.curTrack {
+		// player was destroyed, or the track has already changed again
+		// (e.g. handleOnTrackChange already reconciled it) - stale reply
+		return
+	}
+	j.resyncFromStatus(stat)
+}
+
+// resyncFromStatus reconciles local position tracking against an
+// authoritative status response for the currently known track (does not
+// handle the track having changed - see handleOnTrackChange for that).
+func (j *JukeboxPlayer) resyncFromStatus(stat *mediaprovider.JukeboxStatus) {
+	j.lastStartTime = int(stat.PositionSeconds)
+	j.stopwatch.Reset()
+	if j.state == playing {
+		j.stopwatch.Start()
+	}
+	j.trackChangeTimer.Reset(j.remainingTrackTime())
+	j.InvokeOnSeek()
 }

--- a/backend/player/jukebox/jukeboxplayer.go
+++ b/backend/player/jukebox/jukeboxplayer.go
@@ -31,11 +31,9 @@ type JukeboxPlayer struct {
 
 	trackChangeTimer common.TrackChangeTimer
 
-	curTrack           int
-	queueLength        int
-	curTrackDuration   float64
-	startTrackTime     float64
-	startedAtUnixMilli int64
+	curTrack         int
+	queueLength      int
+	curTrackDuration float64
 }
 
 func NewJukeboxPlayer(provider mediaprovider.JukeboxProvider) (*JukeboxPlayer, error) {
@@ -60,11 +58,12 @@ func (j *JukeboxPlayer) Continue() error {
 	if j.state == playing {
 		return nil
 	}
-	if err := j.startAndUpdateTime(); err != nil {
+	if err := j.provider.JukeboxStart(); err != nil {
 		return err
 	}
 
 	j.state = playing
+	j.stopwatch.Start()
 	j.InvokeOnPlaying()
 	return nil
 }
@@ -76,7 +75,7 @@ func (j *JukeboxPlayer) Pause() error {
 	if err := j.provider.JukeboxStop(); err != nil {
 		return err
 	}
-	// TODO: calculate paused at time
+	j.stopwatch.Stop()
 	j.state = paused
 	j.InvokeOnPaused()
 	return nil
@@ -90,22 +89,34 @@ func (j *JukeboxPlayer) Stop(_ bool) error {
 		return err
 	}
 	j.state = stopped
+	j.lastStartTime = 0
+	j.stopwatch.Reset()
 	j.InvokeOnStopped()
 	return nil
 }
 
-func (j *JukeboxPlayer) PlayTrack(track *mediaprovider.Track, _ float64) error {
+func (j *JukeboxPlayer) PlayTrack(track *mediaprovider.Track, startTime float64) error {
 	if err := j.provider.JukeboxSet(track.ID); err != nil {
 		return err
 	}
-	j.startTrackTime = 0
-	if err := j.startAndUpdateTime(); err != nil {
+	if err := j.provider.JukeboxStart(); err != nil {
 		return err
 	}
 
 	j.curTrack = 0
 	j.queueLength = 1
 	j.curTrackDuration = track.Duration.Seconds()
+
+	if startTime > 0 {
+		if err := j.provider.JukeboxSeek(j.curTrack, int(startTime)); err != nil {
+			return err
+		}
+	}
+	j.lastStartTime = int(startTime)
+	j.stopwatch.Reset()
+	j.stopwatch.Start()
+	j.state = playing
+	j.InvokeOnPlaying()
 
 	return nil
 }
@@ -148,9 +159,9 @@ func (j *JukeboxPlayer) GetStatus() player.Status {
 	}
 
 	return player.Status{
-		State:   state,
-		TimePos: j.curPlayPos().Seconds(),
-		//Duration: TODO
+		State:    state,
+		TimePos:  j.curPlayPos().Seconds(),
+		Duration: j.curTrackDuration,
 	}
 }
 
@@ -174,17 +185,4 @@ func (j *JukeboxPlayer) handleOnTrackChange() {
 		j.trackChangeTimer.Reset(0 /*TODO: next track time*/)
 		j.InvokeOnTrackChange()
 	}
-}
-
-func (j *JukeboxPlayer) startAndUpdateTime() error {
-	beforeStart := time.Now()
-	if err := j.provider.JukeboxStart(); err != nil {
-		return err
-	}
-	afterStart := time.Now()
-
-	// assume track started playing at (ie has been playing for)
-	// half the round-trip latency
-	j.startedAtUnixMilli = time.Now().Add(-afterStart.Sub(beforeStart)).UnixMilli()
-	return nil
 }

--- a/backend/player/jukebox/jukeboxplayer.go
+++ b/backend/player/jukebox/jukeboxplayer.go
@@ -73,7 +73,21 @@ func (j *JukeboxPlayer) SetVolume(vol int) error {
 	return nil
 }
 
+// GetVolume queries the server for the jukebox's actual current volume,
+// rather than relying purely on the last value set through this player
+// instance. This matters right after switching to the Jukebox player: with a
+// freshly constructed JukeboxPlayer, j.volume defaults to its zero value, and
+// PlaybackManager reads GetVolume() immediately to decide whether to fire a
+// volume-changed callback (see playbackEngine.SetPlayer) - without querying
+// the server, that would always report 0 and yank the volume slider down
+// regardless of the jukebox's actual (possibly nonzero) volume.
 func (j *JukeboxPlayer) GetVolume() int {
+	if j.destroyed {
+		return j.volume
+	}
+	if stat, err := j.provider.JukeboxGetStatus(); err == nil {
+		j.volume = stat.Volume
+	}
 	return j.volume
 }
 

--- a/backend/player/jukebox/jukeboxplayer.go
+++ b/backend/player/jukebox/jukeboxplayer.go
@@ -2,6 +2,7 @@ package jukebox
 
 import (
 	"log"
+	"sync"
 	"time"
 
 	"github.com/supersonic-app/supersonic/backend/mediaprovider"
@@ -29,7 +30,22 @@ const retryDelay = 2 * time.Second
 type JukeboxPlayer struct {
 	player.BasePlayerCallbackImpl
 
-	provider  mediaprovider.JukeboxProvider
+	provider mediaprovider.JukeboxProvider
+
+	// mu guards every field below, and is held for the full duration of any
+	// operation that issues Subsonic JukeboxControl requests (set/add/
+	// remove/start/stop/seek/status). JukeboxPlayer is driven from several
+	// independent goroutines - the playback command queue (PlayTrack, Stop,
+	// Continue, Pause, SeekSeconds), playbackEngine's own poll-timer
+	// (SetNextTrack), trackChangeTimer's dispatcher (handleOnTrackChange, via
+	// time.AfterFunc - see common.TrackChangeTimer), and scheduleSync's
+	// spawned goroutines. Without serializing them, their JukeboxControl
+	// requests can reach the server out of the order intended, letting local
+	// bookkeeping (curTrack/hasNextTrack) diverge from the server's actual
+	// queue - observed as a spurious "remove" failing server-side and,
+	// downstream, the same track playing again instead of the next one.
+	mu sync.Mutex
+
 	destroyed bool
 
 	state   int // stopped, playing, paused
@@ -66,6 +82,9 @@ func NewJukeboxPlayer(provider mediaprovider.JukeboxProvider) (*JukeboxPlayer, e
 }
 
 func (j *JukeboxPlayer) SetVolume(vol int) error {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
 	if j.destroyed {
 		return nil
 	}
@@ -85,6 +104,9 @@ func (j *JukeboxPlayer) SetVolume(vol int) error {
 // the server, that would always report 0 and yank the volume slider down
 // regardless of the jukebox's actual (possibly nonzero) volume.
 func (j *JukeboxPlayer) GetVolume() int {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
 	if j.destroyed {
 		return j.volume
 	}
@@ -95,16 +117,21 @@ func (j *JukeboxPlayer) GetVolume() int {
 }
 
 func (j *JukeboxPlayer) Continue() error {
+	j.mu.Lock()
 	if j.destroyed || j.state == playing {
+		j.mu.Unlock()
 		return nil
 	}
 	if err := j.provider.JukeboxStart(); err != nil {
+		j.mu.Unlock()
 		return err
 	}
 
 	j.state = playing
 	j.stopwatch.Start()
 	j.trackChangeTimer.Reset(j.remainingTrackTime())
+	j.mu.Unlock()
+
 	j.InvokeOnPlaying()
 
 	go j.scheduleSync(syncSettleDelay)
@@ -112,42 +139,56 @@ func (j *JukeboxPlayer) Continue() error {
 }
 
 func (j *JukeboxPlayer) Pause() error {
+	j.mu.Lock()
 	if j.destroyed || j.state != playing {
+		j.mu.Unlock()
 		return nil
 	}
 	if err := j.provider.JukeboxStop(); err != nil {
+		j.mu.Unlock()
 		return err
 	}
 	j.trackChangeTimer.Reset(0)
 	j.stopwatch.Stop()
 	j.state = paused
+	j.mu.Unlock()
+
 	j.InvokeOnPaused()
 	return nil
 }
 
 func (j *JukeboxPlayer) Stop(_ bool) error {
+	j.mu.Lock()
 	if j.destroyed || j.state == stopped {
+		j.mu.Unlock()
 		return nil
 	}
 	if err := j.provider.JukeboxStop(); err != nil {
+		j.mu.Unlock()
 		return err
 	}
 	j.trackChangeTimer.Reset(0)
 	j.state = stopped
 	j.lastStartTime = 0
 	j.stopwatch.Reset()
+	j.mu.Unlock()
+
 	j.InvokeOnStopped()
 	return nil
 }
 
 func (j *JukeboxPlayer) PlayTrack(track *mediaprovider.Track, startTime float64) error {
+	j.mu.Lock()
 	if j.destroyed {
+		j.mu.Unlock()
 		return nil
 	}
 	if err := j.provider.JukeboxSet(track.ID); err != nil {
+		j.mu.Unlock()
 		return err
 	}
 	if err := j.provider.JukeboxStart(); err != nil {
+		j.mu.Unlock()
 		return err
 	}
 
@@ -157,6 +198,7 @@ func (j *JukeboxPlayer) PlayTrack(track *mediaprovider.Track, startTime float64)
 
 	if startTime > 0 {
 		if err := j.provider.JukeboxSeek(j.curTrack, int(startTime)); err != nil {
+			j.mu.Unlock()
 			return err
 		}
 	}
@@ -165,6 +207,8 @@ func (j *JukeboxPlayer) PlayTrack(track *mediaprovider.Track, startTime float64)
 	j.stopwatch.Start()
 	j.state = playing
 	j.trackChangeTimer.Reset(j.remainingTrackTime())
+	j.mu.Unlock()
+
 	j.InvokeOnPlaying()
 	// PlayTrack is called both for user-initiated track changes (e.g.
 	// skip/select) and when the engine transfers an already-playing track
@@ -183,8 +227,10 @@ func (j *JukeboxPlayer) PlayTrack(track *mediaprovider.Track, startTime float64)
 // SetNextTrack queues track to play after the current one, replacing any
 // previously queued next track. A nil track clears the queued next track,
 // without affecting the currently playing one.
-func (j *JukeboxPlayer) SetNextTrack(track *mediaprovider.Track) error {
+func (j *JukeboxPlayer) SetNextTrack(track *mediaprovider.Track) (err error) {
+	j.mu.Lock()
 	if j.destroyed {
+		j.mu.Unlock()
 		return nil
 	}
 
@@ -199,12 +245,24 @@ func (j *JukeboxPlayer) SetNextTrack(track *mediaprovider.Track) error {
 	// genuinely queued-but-unplayed one - which, depending on how the
 	// server's jukebox reacts to removing its active track, can disrupt
 	// playback (observed: it fell back to replaying the previous track).
-	if stat, err := j.provider.JukeboxGetStatus(); err == nil && stat.Playing {
-		j.reconcileWithStatus(stat)
+	trackChanged := false
+	if stat, statErr := j.provider.JukeboxGetStatus(); statErr == nil && stat.Playing {
+		trackChanged = j.reconcileWithStatus(stat)
 	}
+	// Release the lock and notify the engine of a server-observed track
+	// change (if any) only once we're done touching state below - and only
+	// after unlocking, since InvokeOnTrackChange runs playbackEngine
+	// callbacks synchronously, which can themselves call back into this
+	// player (e.g. another SetNextTrack) and would deadlock on j.mu.
+	defer func() {
+		j.mu.Unlock()
+		if trackChanged {
+			j.InvokeOnTrackChange()
+		}
+	}()
 
 	if j.hasNextTrack {
-		if err := j.provider.JukeboxRemove(j.curTrack + 1); err != nil {
+		if err = j.provider.JukeboxRemove(j.curTrack + 1); err != nil {
 			return err
 		}
 		j.hasNextTrack = false
@@ -215,7 +273,7 @@ func (j *JukeboxPlayer) SetNextTrack(track *mediaprovider.Track) error {
 	}
 
 	// append the new track to the queue
-	if err := j.provider.JukeboxAdd(track.ID); err != nil {
+	if err = j.provider.JukeboxAdd(track.ID); err != nil {
 		return err
 	}
 	j.hasNextTrack = true
@@ -224,7 +282,9 @@ func (j *JukeboxPlayer) SetNextTrack(track *mediaprovider.Track) error {
 }
 
 func (j *JukeboxPlayer) SeekSeconds(secs float64) error {
+	j.mu.Lock()
 	if j.destroyed {
+		j.mu.Unlock()
 		return nil
 	}
 
@@ -232,6 +292,7 @@ func (j *JukeboxPlayer) SeekSeconds(secs float64) error {
 	err := j.provider.JukeboxSeek(j.curTrack, int(secs))
 	j.seeking = false
 	if err != nil {
+		j.mu.Unlock()
 		return err
 	}
 
@@ -241,6 +302,8 @@ func (j *JukeboxPlayer) SeekSeconds(secs float64) error {
 		j.stopwatch.Start()
 	}
 	j.trackChangeTimer.Reset(j.remainingTrackTime())
+	j.mu.Unlock()
+
 	j.InvokeOnSeek()
 
 	go j.scheduleSync(syncSettleDelay)
@@ -248,10 +311,15 @@ func (j *JukeboxPlayer) SeekSeconds(secs float64) error {
 }
 
 func (j *JukeboxPlayer) IsSeeking() bool {
+	j.mu.Lock()
+	defer j.mu.Unlock()
 	return j.seeking
 }
 
 func (j *JukeboxPlayer) GetStatus() player.Status {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
 	state := player.Stopped
 	switch j.state {
 	case playing:
@@ -267,6 +335,7 @@ func (j *JukeboxPlayer) GetStatus() player.Status {
 	}
 }
 
+// curPlayPos must be called with j.mu held.
 func (j *JukeboxPlayer) curPlayPos() time.Duration {
 	return time.Duration(j.lastStartTime)*time.Second + j.stopwatch.Elapsed()
 }
@@ -274,22 +343,29 @@ func (j *JukeboxPlayer) curPlayPos() time.Duration {
 // remainingTrackTime is how long until the current track is expected to end,
 // based on our local bookkeeping of its duration and current position
 // (including time elapsed since the last seek/time sync, not just the
-// position as of then).
+// position as of then). Must be called with j.mu held.
 func (j *JukeboxPlayer) remainingTrackTime() time.Duration {
 	return time.Duration(j.curTrackDuration*float64(time.Second)) - j.curPlayPos()
 }
 
 func (j *JukeboxPlayer) Destroy() {
+	j.mu.Lock()
 	j.destroyed = true
+	j.mu.Unlock()
+
 	j.trackChangeTimer.Reset(0)
 }
 
 // handleOnTrackChange fires when the local trackChangeTimer estimates the
 // current track has finished. Since the server-side jukebox doesn't push
 // playback events, this always reconciles against the server's authoritative
-// JukeboxGetStatus before updating any state.
+// JukeboxGetStatus before updating any state. Runs on trackChangeTimer's own
+// dispatcher goroutine (see common.TrackChangeTimer), independent of
+// whichever goroutine last armed it.
 func (j *JukeboxPlayer) handleOnTrackChange() {
+	j.mu.Lock()
 	if j.destroyed {
+		j.mu.Unlock()
 		return
 	}
 
@@ -299,6 +375,7 @@ func (j *JukeboxPlayer) handleOnTrackChange() {
 		if !j.destroyed {
 			j.trackChangeTimer.Reset(retryDelay)
 		}
+		j.mu.Unlock()
 		return
 	}
 
@@ -317,6 +394,7 @@ func (j *JukeboxPlayer) handleOnTrackChange() {
 			// it - silently killing playback of every track after this
 			// one. Check again shortly instead.
 			j.trackChangeTimer.Reset(retryDelay)
+			j.mu.Unlock()
 			return
 		}
 		// no next track was queued, so the server has genuinely run out of
@@ -324,29 +402,37 @@ func (j *JukeboxPlayer) handleOnTrackChange() {
 		j.state = stopped
 		j.lastStartTime = 0
 		j.stopwatch.Reset()
+		j.mu.Unlock()
 		j.InvokeOnStopped()
 		return
 	}
 
-	j.reconcileWithStatus(stat)
+	trackChanged := j.reconcileWithStatus(stat)
+	j.mu.Unlock()
+	if trackChanged {
+		j.InvokeOnTrackChange()
+	} else {
+		j.InvokeOnSeek()
+	}
 }
 
 // reconcileWithStatus updates local track-position state to match an
 // authoritative JukeboxGetStatus response. If the server has moved on to a
 // different track than we last knew, this performs the same bookkeeping as
-// a natural track change and notifies the engine via InvokeOnTrackChange -
-// so regardless of which poll (the track-change timer firing, scheduleSync,
-// or SetNextTrack's own pre-check) is the one to first observe the server
-// having advanced, the engine always finds out about it the same way.
-// Otherwise, just resyncs the current track's position (see
-// resyncFromStatus).
-func (j *JukeboxPlayer) reconcileWithStatus(stat *mediaprovider.JukeboxStatus) {
+// a natural track change and returns true - so regardless of which poll (the
+// track-change timer firing, scheduleSync, or SetNextTrack's own pre-check)
+// is the one to first observe the server having advanced, the engine always
+// finds out about it the same way (callers must invoke InvokeOnTrackChange
+// once j.mu is released). Otherwise, just resyncs the current track's
+// position (see resyncFromStatusLocked) and returns false (callers should
+// invoke InvokeOnSeek instead). Must be called with j.mu held.
+func (j *JukeboxPlayer) reconcileWithStatus(stat *mediaprovider.JukeboxStatus) bool {
 	if stat.CurrentTrack == j.curTrack {
 		// our local timer fired early due to clock drift - the server
 		// hasn't advanced tracks yet. Resync and re-arm for the
 		// remaining time rather than treating this as a track change.
-		j.resyncFromStatus(stat)
-		return
+		j.resyncFromStatusLocked(stat)
+		return false
 	}
 
 	// the server has advanced to the next track in the queue
@@ -359,40 +445,51 @@ func (j *JukeboxPlayer) reconcileWithStatus(stat *mediaprovider.JukeboxStatus) {
 	j.stopwatch.Reset()
 	j.stopwatch.Start()
 	j.trackChangeTimer.Reset(j.remainingTrackTime())
-	j.InvokeOnTrackChange()
+	return true
 }
 
 // scheduleSync waits the given delay and then reconciles local playback
 // position/state against the server's authoritative JukeboxGetStatus. Used
 // after commands (start/seek) that change server-side playback, to correct
-// for network round-trip latency and any drift in the local estimate.
+// for network round-trip latency and any drift in the local estimate. Runs
+// on its own goroutine (see the `go j.scheduleSync(...)` call sites),
+// independent of whichever goroutine issued the command that spawned it.
 func (j *JukeboxPlayer) scheduleSync(delay time.Duration) {
 	time.Sleep(delay)
+
+	j.mu.Lock()
 	if j.destroyed {
+		j.mu.Unlock()
 		return
 	}
 	stat, err := j.provider.JukeboxGetStatus()
 	if err != nil {
+		j.mu.Unlock()
 		log.Printf("jukebox: failed to sync status: %v", err)
 		return
 	}
 	if j.destroyed || stat.CurrentTrack != j.curTrack {
 		// player was destroyed, or the track has already changed again
 		// (e.g. handleOnTrackChange already reconciled it) - stale reply
+		j.mu.Unlock()
 		return
 	}
-	j.resyncFromStatus(stat)
+	j.resyncFromStatusLocked(stat)
+	j.mu.Unlock()
+
+	j.InvokeOnSeek()
 }
 
-// resyncFromStatus reconciles local position tracking against an
+// resyncFromStatusLocked reconciles local position tracking against an
 // authoritative status response for the currently known track (does not
-// handle the track having changed - see handleOnTrackChange for that).
-func (j *JukeboxPlayer) resyncFromStatus(stat *mediaprovider.JukeboxStatus) {
+// handle the track having changed - see reconcileWithStatus for that). Must
+// be called with j.mu held; callers should invoke InvokeOnSeek once it's
+// released.
+func (j *JukeboxPlayer) resyncFromStatusLocked(stat *mediaprovider.JukeboxStatus) {
 	j.lastStartTime = int(stat.PositionSeconds)
 	j.stopwatch.Reset()
 	if j.state == playing {
 		j.stopwatch.Start()
 	}
 	j.trackChangeTimer.Reset(j.remainingTrackTime())
-	j.InvokeOnSeek()
 }

--- a/backend/player/jukebox/jukeboxplayer.go
+++ b/backend/player/jukebox/jukeboxplayer.go
@@ -43,10 +43,13 @@ type JukeboxPlayer struct {
 
 	trackChangeTimer common.TrackChangeTimer
 
-	// index into the server-side jukebox queue of the currently playing track
-	curTrack int
-	// number of tracks currently in the server-side jukebox queue
-	queueLength      int
+	// index into the server-side jukebox queue of the currently playing
+	// track. Since the server doesn't push playback events, this is only
+	// ever updated from a JukeboxGetStatus response (see
+	// reconcileWithStatus) - never assumed/incremented locally except right
+	// after PlayTrack, where we know it's 0 because JukeboxSet just cleared
+	// the queue.
+	curTrack         int
 	curTrackDuration float64
 
 	// duration of the track queued via SetNextTrack, used to know the new
@@ -149,7 +152,6 @@ func (j *JukeboxPlayer) PlayTrack(track *mediaprovider.Track, startTime float64)
 	}
 
 	j.curTrack = 0
-	j.queueLength = 1
 	j.curTrackDuration = track.Duration.Seconds()
 	j.hasNextTrack = false
 
@@ -186,12 +188,25 @@ func (j *JukeboxPlayer) SetNextTrack(track *mediaprovider.Track) error {
 		return nil
 	}
 
-	// we need to replace the last track in the queue, remove it first
-	if j.curTrack < j.queueLength-1 {
+	// Reconcile against the server's authoritative queue position first.
+	// This is called once per track, close to its end (see
+	// playbackEngine.handleTimePosUpdate's isNearEnd check), which is also
+	// exactly when our own track-change-timer estimate is most likely to
+	// still be stale relative to the server's true state (e.g. our
+	// estimate of the current track's duration ran a bit long). If we
+	// computed the index to remove/add from a stale j.curTrack, we could
+	// end up operating on the currently-playing entry instead of a
+	// genuinely queued-but-unplayed one - which, depending on how the
+	// server's jukebox reacts to removing its active track, can disrupt
+	// playback (observed: it fell back to replaying the previous track).
+	if stat, err := j.provider.JukeboxGetStatus(); err == nil && stat.Playing {
+		j.reconcileWithStatus(stat)
+	}
+
+	if j.hasNextTrack {
 		if err := j.provider.JukeboxRemove(j.curTrack + 1); err != nil {
 			return err
 		}
-		j.queueLength -= 1
 		j.hasNextTrack = false
 	}
 
@@ -203,7 +218,6 @@ func (j *JukeboxPlayer) SetNextTrack(track *mediaprovider.Track) error {
 	if err := j.provider.JukeboxAdd(track.ID); err != nil {
 		return err
 	}
-	j.queueLength += 1
 	j.hasNextTrack = true
 	j.nextTrackDuration = track.Duration.Seconds()
 	return nil
@@ -298,6 +312,19 @@ func (j *JukeboxPlayer) handleOnTrackChange() {
 		return
 	}
 
+	j.reconcileWithStatus(stat)
+}
+
+// reconcileWithStatus updates local track-position state to match an
+// authoritative JukeboxGetStatus response. If the server has moved on to a
+// different track than we last knew, this performs the same bookkeeping as
+// a natural track change and notifies the engine via InvokeOnTrackChange -
+// so regardless of which poll (the track-change timer firing, scheduleSync,
+// or SetNextTrack's own pre-check) is the one to first observe the server
+// having advanced, the engine always finds out about it the same way.
+// Otherwise, just resyncs the current track's position (see
+// resyncFromStatus).
+func (j *JukeboxPlayer) reconcileWithStatus(stat *mediaprovider.JukeboxStatus) {
 	if stat.CurrentTrack == j.curTrack {
 		// our local timer fired early due to clock drift - the server
 		// hasn't advanced tracks yet. Resync and re-arm for the

--- a/backend/player/jukebox/jukeboxplayer.go
+++ b/backend/player/jukebox/jukeboxplayer.go
@@ -150,6 +150,15 @@ func (j *JukeboxPlayer) PlayTrack(track *mediaprovider.Track, startTime float64)
 	j.state = playing
 	j.trackChangeTimer.Reset(j.remainingTrackTime())
 	j.InvokeOnPlaying()
+	// PlayTrack is called both for user-initiated track changes (e.g.
+	// skip/select) and when the engine transfers an already-playing track
+	// to this player (e.g. switching cast devices mid-song). Either way,
+	// the engine only advances its own now-playing index/UI in response to
+	// this callback - matches DLNAPlayer.PlayFile.
+	j.InvokeOnTrackChange()
+	if startTime > 0 {
+		j.InvokeOnSeek()
+	}
 
 	go j.scheduleSync(syncSettleDelay)
 	return nil

--- a/backend/player/jukebox/jukeboxplayer_test.go
+++ b/backend/player/jukebox/jukeboxplayer_test.go
@@ -1,0 +1,153 @@
+package jukebox
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/supersonic-app/supersonic/backend/mediaprovider"
+)
+
+// fakeJukeboxProvider is a minimal, concurrency-safe stand-in for a real
+// Subsonic server, used to exercise JukeboxPlayer from multiple goroutines
+// at once under the race detector.
+type fakeJukeboxProvider struct {
+	mu       sync.Mutex
+	queue    []string
+	curTrack int
+	playing  bool
+}
+
+func (f *fakeJukeboxProvider) JukeboxStart() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.playing = len(f.queue) > 0
+	return nil
+}
+
+func (f *fakeJukeboxProvider) JukeboxStop() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.playing = false
+	return nil
+}
+
+func (f *fakeJukeboxProvider) JukeboxSeek(idx, seconds int) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.curTrack = idx
+	return nil
+}
+
+func (f *fakeJukeboxProvider) JukeboxClear() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.queue = nil
+	f.curTrack = 0
+	f.playing = false
+	return nil
+}
+
+func (f *fakeJukeboxProvider) JukeboxAdd(trackID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.queue = append(f.queue, trackID)
+	return nil
+}
+
+func (f *fakeJukeboxProvider) JukeboxRemove(idx int) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if idx < 0 || idx >= len(f.queue) {
+		return errIndexOutOfRange
+	}
+	f.queue = append(f.queue[:idx], f.queue[idx+1:]...)
+	return nil
+}
+
+func (f *fakeJukeboxProvider) JukeboxGetStatus() (*mediaprovider.JukeboxStatus, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return &mediaprovider.JukeboxStatus{
+		CurrentTrack: f.curTrack,
+		Playing:      f.playing,
+	}, nil
+}
+
+func (f *fakeJukeboxProvider) JukeboxSet(trackID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.queue = []string{trackID}
+	f.curTrack = 0
+	f.playing = true
+	return nil
+}
+
+func (f *fakeJukeboxProvider) JukeboxSetVolume(vol int) error { return nil }
+func (f *fakeJukeboxProvider) JukeboxSupported() bool         { return true }
+
+type fakeErr string
+
+func (e fakeErr) Error() string { return string(e) }
+
+const errIndexOutOfRange = fakeErr("index out of range")
+
+// TestJukeboxPlayer_ConcurrentAccess drives PlayTrack, SetNextTrack,
+// SeekSeconds and the internal track-change/status-sync goroutines from many
+// goroutines at once, mirroring how playbackEngine actually calls
+// JukeboxPlayer: PlayTrack/SeekSeconds from the serialized command queue,
+// SetNextTrack from an independent poll ticker, and handleOnTrackChange from
+// trackChangeTimer's own dispatcher goroutine. This is a regression test for
+// a data race in JukeboxPlayer's unsynchronized state (curTrack,
+// hasNextTrack, ...) that could let concurrent requests reach the server out
+// of order and desync local bookkeeping from the server's actual queue.
+func TestJukeboxPlayer_ConcurrentAccess(t *testing.T) {
+	provider := &fakeJukeboxProvider{}
+	j, err := NewJukeboxPlayer(provider)
+	if err != nil {
+		t.Fatalf("NewJukeboxPlayer: %v", err)
+	}
+	var trackChanges int64
+	j.OnTrackChange(func() { atomic.AddInt64(&trackChanges, 1) })
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n * 3)
+	for i := 0; i < n; i++ {
+		track := &mediaprovider.Track{}
+		track.ID = "track-a"
+		track.Duration = 3 * time.Second
+
+		next := &mediaprovider.Track{}
+		next.ID = "track-b"
+		next.Duration = 3 * time.Second
+
+		go func() {
+			defer wg.Done()
+			_ = j.PlayTrack(track, 0)
+		}()
+		go func() {
+			defer wg.Done()
+			_ = j.SetNextTrack(next)
+		}()
+		go func() {
+			defer wg.Done()
+			_ = j.SeekSeconds(1)
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("concurrent calls did not return in time")
+	}
+
+	j.Destroy()
+}

--- a/res/translations/en.json
+++ b/res/translations/en.json
@@ -149,6 +149,7 @@
     "Is favorite": "Is favorite",
     "Is not favorite": "Is not favorite",
     "Jan": "Jan",
+    "Jukebox": "Jukebox",
     "Jul": "Jul",
     "Jun": "Jun",
     "Language": "Language",

--- a/ui/controller/controller.go
+++ b/ui/controller/controller.go
@@ -166,14 +166,20 @@ func (m *Controller) ShowCastMenu(onPendingPlayerChange func()) {
 	for _, d := range devices {
 		_d := d
 		isCurrent := rp != nil && _d.URL == rp.URL
-		item := fyne.NewMenuItem(d.Name, func() {
+		label := d.Name
+		if d.Protocol == backend.JukeboxProtocol {
+			// unlike DLNA device names (fetched from the network device
+			// itself), the Jukebox device name is a fixed app-level label
+			label = lang.L("Jukebox")
+		}
+		item := fyne.NewMenuItem(label, func() {
 			if isCurrent {
 				return // no-op.
 			}
 			onPendingPlayerChange()
 			go func() {
 				if err := m.App.PlaybackManager.SetRemotePlayer(&_d); err != nil {
-					fyne.Do(func() { m.ToastProvider.ShowErrorToast("Failed to connect to " + _d.Name) })
+					fyne.Do(func() { m.ToastProvider.ShowErrorToast("Failed to connect to " + label) })
 				}
 			}()
 		})


### PR DESCRIPTION
First of all I'm happy I've found this lightweight no-BS player. However, I really miss the jukebox feature and luckily there's already a branch for it, so I decided to spin up my agent and finish it.

I'm already testing the code and it works fine for me. I can freely switch between "This computer" and "Jukebox" and the playback resumes seamlessly.

The following is the AI summary of the changes:

## Summary

Continues/completes the `jukebox` branch (started by @dweymouth) toward closing #300. As noted in that issue's comments, the branch had a working backend API layer (`mediaprovider.JukeboxProvider` + Subsonic implementation) but was never wired up to be reachable or fully functional.

This PR:

- Wires `JukeboxPlayer` into `PlaybackManager`'s cast-device list, so it's selectable alongside DLNA devices
- Adds the "Jukebox" entry to the cast menu
- Fixes local playback-position tracking in `JukeboxPlayer` (the stopwatch was never actually started, `PlayTrack` never set `state=playing`, `GetStatus()` never reported `Duration`)
- Implements status polling/reconciliation against the server's authoritative `JukeboxGetStatus`, and track-change detection (the Subsonic jukebox API has no push/event mechanism, so this is all poll-driven, mirroring `DLNAPlayer`'s `syncPlaybackTime`/`handleOnTrackChange` pattern)
- Probes whether the connected server actually supports/allows jukebox playback (not all Subsonic-compatible servers do, and there's no capability-negotiation mechanism for it), so the cast menu entry doesn't appear at all for servers where it would just fail
- Fixes a latent concurrency bug in `common.TrackChangeTimer` (shared by `DLNAPlayer` and `JukeboxPlayer`) that could deadlock the entire playback command queue - found via manual testing of this branch, see commit `common: fix TrackChangeTimer deadlock on concurrent Reset calls` for the full root-cause writeup
- Fixes the UI not updating when skipping tracks while on the Jukebox player (`InvokeOnTrackChange` was never fired from `PlayTrack`)
- Fixes `GetVolume()` reporting 0 right after switching to Jukebox instead of the server's actual current volume

Each commit is self-contained with a detailed message; probably easiest to review commit-by-commit rather than as a squashed diff.

## Testing

Manually tested end-to-end against a real Navidrome instance (0.63.2): connecting, switching to/from Jukebox mid-playback, play/pause/seek/skip, volume control, and multi-track queue playback. Added a regression test for the `TrackChangeTimer` deadlock fix (`go test ./backend/player/common/... -race`).

Not yet covered (opening as draft for this reason):
- Broader automated test coverage for `JukeboxPlayer`'s state machine
- i18n strings beyond English (`en.json`)
- User-facing docs/README mention of Jukebox support

## Notes for review

- Only tested against Navidrome; haven't been able to test against other Subsonic-API servers with jukebox support (e.g. Gonic, Airsonic).
- `JukeboxSupported()` probes via a `status` `jukeboxControl` call and caches the result for the provider's lifetime - happy to adjust the caching strategy if there's a preference (e.g. re-probing after some interval).
