### PR TITLE
Reuse a single mpv core for waveform WAV conversion

### DIFF
--- a/backend/playbackmanager.go
+++ b/backend/playbackmanager.go
@@ -771,6 +771,9 @@ func (p *PlaybackManager) Stop() {
 
 func (p *PlaybackManager) Shutdown() {
 	p.cmdQueue.StopAndWait()
+	if p.wfmGen != nil {
+		p.wfmGen.Close()
+	}
 }
 
 func (p *PlaybackManager) Pause() {

--- a/backend/waveformimage.go
+++ b/backend/waveformimage.go
@@ -23,6 +23,16 @@ import (
 
 type WaveformImageGenerator struct {
 	audioCache *AudioCache
+
+	// converter is a single, long-lived mpv core used to transcode audio
+	// files to WAV for waveform analysis. Previously a new mpv core was
+	// created and destroyed for every waveform job (i.e. on every track
+	// switch that wasn't already cached); reusing one core instead avoids
+	// repeated full libmpv init/teardown cycles right at track-switch time.
+	converterOnce sync.Once
+	converter     *mpv.Mpv
+	converterErr  error
+	convertMu     sync.Mutex // serializes use of the shared converter core
 }
 
 // Buffer pool for waveform analysis to reduce allocations
@@ -435,33 +445,64 @@ func float64ToByte(val float64) byte {
 	return byte(val * 255)
 }
 
+// converterCore lazily creates the single, long-lived mpv core used for all
+// WAV conversions. It's created on first use rather than in
+// NewWaveformImageGenerator so that if waveform generation is never
+// triggered, no mpv core is ever spun up.
+func (w *WaveformImageGenerator) converterCore() (*mpv.Mpv, error) {
+	w.converterOnce.Do(func() {
+		m := mpv.Create()
+		// Don't load the user's mpv config/scripts into this internal,
+		// invisible, disk-to-disk conversion core.
+		m.SetOptionString("config", "no")
+		m.SetOptionString("video", "no")
+		m.SetOptionString("audio-display", "no")
+		m.SetOptionString("terminal", "no")
+		m.SetOptionString("idle", "yes")
+		// Screensaver inhibition is meaningless for a silent, invisible
+		// conversion job.
+		m.SetOptionString("stop-screensaver", "no")
+		m.SetOptionString("ao", "pcm")
+		m.SetOption("volume", mpv.FORMAT_INT64, 100)
+		// no need to preserve full sample resolution just for waveform image
+		// let's make less data to process and smaller on-disk file
+		m.SetOption("audio-samplerate", mpv.FORMAT_INT64, 22050)
+		m.SetOptionString("audio-channels", "mono")
+		m.SetOptionString("audio-format", "s16")
+		if err := m.Initialize(); err != nil {
+			w.converterErr = err
+			return
+		}
+		w.converter = m
+	})
+	return w.converter, w.converterErr
+}
+
 func (w *WaveformImageGenerator) convertToWav(ctx context.Context, id, inPath, outPath string) error {
-	m := mpv.Create()
-	m.SetOptionString("video", "no")
-	m.SetOptionString("audio-display", "no")
-	m.SetOptionString("terminal", "no")
-	m.SetOptionString("idle", "yes")
-	m.SetOptionString("ao-pcm-file", outPath)
-	m.SetOptionString("ao", "pcm")
-	m.SetOption("volume", mpv.FORMAT_INT64, 100)
-	// no need to preserve full sample resolution just for waveform image
-	// let's make less data to process and smaller on-disk file
-	m.SetOption("audio-samplerate", mpv.FORMAT_INT64, 22050)
-	m.SetOptionString("audio-channels", "mono")
-	m.SetOptionString("audio-format", "s16")
-	if err := m.Initialize(); err != nil {
+	m, err := w.converterCore()
+	if err != nil {
 		return err
 	}
 
-	defer m.TerminateDestroy()
+	// Only one conversion can run on the shared core at a time.
+	w.convertMu.Lock()
+	defer w.convertMu.Unlock()
 
-	m.Command([]string{"loadfile", inPath, "replace"})
+	if err := m.SetOptionString("ao-pcm-file", outPath); err != nil {
+		return err
+	}
+	if err := m.Command([]string{"loadfile", inPath, "replace"}); err != nil {
+		return err
+	}
 	defer w.audioCache.ReleaseReferenceToFile(id)
 
 	// Wait for MPV idle or ctx expiry
 	for {
 		select {
 		case <-ctx.Done():
+			// Stop this job's playback so the shared core is idle again
+			// and ready for the next queued conversion.
+			m.Command([]string{"stop"})
 			return ctx.Err()
 		default:
 			// use small timeout to allow detecting ctx expiry
@@ -481,6 +522,19 @@ func (w *WaveformImageGenerator) convertToWav(ctx context.Context, id, inPath, o
 				return nil
 			}
 		}
+	}
+}
+
+// Close releases the shared mpv core used for waveform conversion, if one
+// was ever created. Must be called during app shutdown to avoid leaking the
+// mpv core; safe to call even if no conversion was ever performed.
+func (w *WaveformImageGenerator) Close() {
+	w.convertMu.Lock()
+	defer w.convertMu.Unlock()
+	if w.converter != nil {
+		w.converter.Command([]string{"stop"})
+		w.converter.TerminateDestroy()
+		w.converter = nil
 	}
 }
 


### PR DESCRIPTION
## What

`WaveformImageGenerator.convertToWav` previously created and fully tore down a brand-new libmpv core (`mpv.Create()` → `Initialize()` → `TerminateDestroy()`) for every waveform-generation job — i.e. on every track switch to a track not already in the waveform cache. This reuses a single, lazily-created, long-lived converter core across all waveform jobs instead (serialized with a mutex), mirroring the pattern the app already uses for the main playback core (`App.LocalPlayer`).

Also hardens that core with:
- `--no-config`, so no host `mpv.conf`/scripts get pulled into this internal, invisible, disk-to-disk conversion core
- `stop-screensaver=no`, which is meaningless for a silent, non-visible conversion job

`WaveformImageGenerator.Close()` releases the shared core and is wired into `PlaybackManager.Shutdown()` so it doesn't leak.

## Why

I was chasing an intermittent GNOME Shell/Mutter session crash (`BadWindow`, X `SendEvent`, whole session torn down) that correlated with Supersonic switching tracks. Tracing the code, this per-track full libmpv init/teardown cycle was the one Supersonic-internal path most tightly correlated with the crash timing in my logs (the "MPV convert" warning appeared immediately before the fatal X error). I don't have proof this is *the* root cause — GNOME Shell shouldn't crash the whole session regardless of what a client does, and I'm also looking at whether it's an MPRIS-driven race in Shell's own media-controls widget instead — but this seemed like a worthwhile fix on its own merits regardless: it removes a real, repeated, avoidable resource-churn pattern (full library init/teardown per track) and closes off a plausible host-config bleed-through path (`--no-config`).

## Trade-off

Waveform conversion for the prefetched next track and the current track can no longer run concurrently (previously each had its own core); they now serialize through the shared core's mutex. In practice this is a small, likely sub-second effect for local/typical files, traded for eliminating the repeated full-library init/teardown.

## Testing

- `go build -tags migrated_fynedo`, `go vet ./...`, `go test ./backend/...` all pass.
- Ran a patched build against my real Jellyfin library with a fresh (empty) waveform/audio cache to force real cache misses: 21 waveform conversions through the shared core across a shuffled playlist, including 15 skips at ~1s intervals and then 20 more back-to-back skips with no delay (worst case for the new mutex serialization). No crash, no hang, no deadlock. Clean shutdown via `Close()`.

Not a confirmed fix for the GNOME-side crash — opening as a draft for early feedback on the approach while I keep isolating the actual trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
