### PR TITLE
Add support for casting to Sonos speakers

### DIFF
--- a/backend/playbackmanager.go
+++ b/backend/playbackmanager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/supersonic-app/supersonic/backend/player"
 	"github.com/supersonic-app/supersonic/backend/player/dlna"
 	"github.com/supersonic-app/supersonic/backend/player/mpv"
+	"github.com/supersonic-app/supersonic/backend/player/sonos"
 	"github.com/supersonic-app/supersonic/sharedutil"
 )
 
@@ -256,8 +257,23 @@ func (p *PlaybackManager) ScanRemotePlayers(ctx context.Context, fastScan bool) 
 func (p *PlaybackManager) scanRemotePlayers(ctx context.Context, waitSec int) {
 	devices, _ := device.SearchMediaRenderers(ctx, waitSec, services.AVTransport, services.RenderingControl)
 
+	// Sonos advertises each speaker separately, so collapse them into the
+	// zone groups the user actually plays to before listing anything.
+	groups, devices := sonos.Groups(ctx, devices)
+
 	coverArtPathFn := p.CoverArtPathFn
 	var discovered []RemotePlaybackDevice
+	for _, g := range groups {
+		rp := RemotePlaybackDevice{
+			Name:     g.Name,
+			URL:      g.Coordinator.URL,
+			Protocol: "Sonos",
+			new: func() (player.BasePlayer, error) {
+				return dlna.NewDLNAPlayer(g.Coordinator, coverArtPathFn)
+			},
+		}
+		discovered = append(discovered, rp)
+	}
 	for _, d := range devices {
 		rp := RemotePlaybackDevice{
 			Name:     d.FriendlyName,

--- a/backend/player/dlna/dlnaplayer.go
+++ b/backend/player/dlna/dlnaplayer.go
@@ -1,6 +1,7 @@
 package dlna
 
 import (
+	"bytes"
 	"context"
 	"crypto/md5"
 	"encoding/base64"
@@ -100,6 +101,7 @@ func NewDLNAPlayer(device *device.MediaRenderer, coverArtPathFn func(coverArtID 
 	retry.RetryMax = 3
 	retry.RetryWaitMin = 100 * time.Millisecond
 	retry.Logger = retryLogger{}
+	retry.HTTPClient.Transport = lengthedBodyTransport{retry.HTTPClient.Transport}
 	cli := retry.StandardClient()
 
 	avt, err := device.AVTransportClient()
@@ -681,6 +683,36 @@ func (d *DLNAPlayer) _updateProxyURL(key, url string) {
 	copy(d.proxyURLs[:], d.proxyURLs[1:])
 	// Insert new element at the most recent position
 	d.proxyURLs[len(d.proxyURLs)-1] = proxyMapEntry{key: key, url: url}
+}
+
+// lengthedBodyTransport buffers request bodies of unknown length so that
+// they are sent with a Content-Length instead of chunked encoding.
+// go-upnpcast builds its SOAP bodies from readers, and Sonos players
+// refuse to answer chunked control requests.
+type lengthedBodyTransport struct {
+	http.RoundTripper
+}
+
+func (t lengthedBodyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// A body of unknown length carries no ContentLength, which for a
+	// non-empty body is what makes net/http fall back to chunking.
+	if req.Body == nil || req.ContentLength > 0 {
+		return t.RoundTripper.RoundTrip(req)
+	}
+
+	body, err := io.ReadAll(req.Body)
+	req.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	req = req.Clone(req.Context())
+	req.ContentLength = int64(len(body))
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(body)), nil
+	}
+	return t.RoundTripper.RoundTrip(req)
 }
 
 // httpClientHandler wraps an http.Client to implement services.RequestHandler

--- a/backend/player/dlna/dlnaplayer.go
+++ b/backend/player/dlna/dlnaplayer.go
@@ -32,6 +32,9 @@ const (
 	paused  = 2
 )
 
+// AVTransport state reported by a device that is still loading media
+const transitioning = "TRANSITIONING"
+
 type proxyMapEntry struct {
 	key string
 	url string
@@ -78,9 +81,10 @@ type DLNAPlayer struct {
 
 	// keep in order of most recently accessed at the end
 	// that way the item in proxyURLs[0] can be kicked out
-	// when adding a new URL to the proxy, since
-	// only two will need to be active at any given time
-	proxyURLs    [3]proxyMapEntry
+	// when adding a new URL to the proxy. The current and the next
+	// track each occupy a stream and a cover art entry, and the
+	// track they replaced can still be being read.
+	proxyURLs    [6]proxyMapEntry
 	proxyURLLock sync.Mutex
 
 	// If SetNextAVTransport fails (e.g. because the device
@@ -121,6 +125,10 @@ func NewDLNAPlayer(device *device.MediaRenderer, coverArtPathFn func(coverArtID 
 	if _, err := avt.GetTransportInfo(ctx); err != nil {
 		return nil, fmt.Errorf("failed to connect to %s", device.FriendlyName)
 	}
+
+	// a renderer that was left muted plays silence, and Supersonic
+	// offers no way to unmute it
+	rc.SetMute(ctx, false)
 
 	return &DLNAPlayer{
 		avTransport:    avt,
@@ -204,15 +212,14 @@ func (d *DLNAPlayer) PlayFile(urlstr string, meta mediaprovider.MediaItemMetadat
 	}
 	d.pendingPlayStart = true
 	if startTime > 0 {
-		// TODO: do something better than this!!
-		time.Sleep(2 * time.Second)
+		d.awaitPlaybackStart()
 		if !d.destroyed {
 			d.sendSeekCmd(startTime)
 		}
 		d.pendingPlayStart = false
 	} else {
 		go func() {
-			time.Sleep(2 * time.Second)
+			d.awaitPlaybackStart()
 			if !d.destroyed {
 				d.syncPlaybackTime()
 			}
@@ -249,6 +256,26 @@ func (d *DLNAPlayer) playAVTransportMedia(media *avtransport.MediaItem) error {
 	return nil
 }
 
+// awaitPlaybackStart waits for the renderer to finish loading the media it
+// was handed. A seek sent while the device is still transitioning is
+// silently dropped - Sonos answers it 200 OK and keeps playing from the
+// start of the track - so commands must wait for the transition to end.
+func (d *DLNAPlayer) awaitPlaybackStart() {
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		time.Sleep(200 * time.Millisecond)
+		if d.destroyed {
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		info, err := d.avTransport.GetTransportInfo(ctx)
+		cancel()
+		if err == nil && info.State != transitioning {
+			return
+		}
+	}
+}
+
 func (d *DLNAPlayer) SetNextFile(url string, meta mediaprovider.MediaItemMetadata) error {
 	if d.destroyed {
 		return nil
@@ -273,12 +300,19 @@ func (d *DLNAPlayer) SetNextFile(url string, meta mediaprovider.MediaItemMetadat
 	d.cancelRequest = cancel
 	defer cancel()
 	err := d.avTransport.SetNextAVTransportMedia(ctx, media)
-	if err != nil {
-		d.metaLock.Lock()
+
+	d.metaLock.Lock()
+	// Clearing the queue has nothing to fall back to, and succeeding
+	// here must drop any item a previous failure left behind, so that
+	// the next track change does not start playing it.
+	if err != nil && url != "" {
 		d.failedToSetNext = true
 		d.unsetNextMediaItem = media
-		d.metaLock.Unlock()
+	} else {
+		d.failedToSetNext = false
+		d.unsetNextMediaItem = nil
 	}
+	d.metaLock.Unlock()
 	return err
 }
 

--- a/backend/player/dlna/dlnaplayer.go
+++ b/backend/player/dlna/dlnaplayer.go
@@ -587,9 +587,10 @@ func (d *DLNAPlayer) handleOnTrackChange() {
 	d.metaLock.Unlock()
 
 	if stopping {
-		d.lastStartTime = 0
-		d.stopwatch.Reset()
-		d.InvokeOnStopped()
+		// The renderer has to be told to stop, not just left to run off
+		// the end of the stream: a Sonos player that reaches the end of
+		// one resumes whatever session it was playing beforehand.
+		d.Stop(false)
 	} else {
 		d.metaLock.Lock()
 		if d.failedToSetNext {

--- a/backend/player/dlna/dlnaplayer_test.go
+++ b/backend/player/dlna/dlnaplayer_test.go
@@ -1,0 +1,55 @@
+package dlna
+
+import "testing"
+
+// The current and the next track each put a stream and a cover art URL
+// into the proxy. All four have to stay reachable: if the current track's
+// stream is evicted, a seek makes the renderer fetch a 404 and skip to
+// whatever it has queued next.
+func TestProxyKeepsCurrentAndNextTrackReachable(t *testing.T) {
+	d := &DLNAPlayer{}
+
+	added := []struct {
+		name string
+		url  string
+		key  string
+	}{
+		{"current stream", "http://server/stream?id=cur", ""},
+		{"current art", "/cache/art/cur.jpg", ""},
+		{"next stream", "http://server/stream?id=next", ""},
+		{"next art", "/cache/art/next.jpg", ""},
+	}
+	for i := range added {
+		added[i].key = d.addURLToProxy(added[i].url)
+	}
+
+	for _, a := range added {
+		got, ok := d.lookupProxyURL(a.key)
+		if !ok {
+			t.Errorf("%s was evicted from the proxy", a.name)
+		} else if got != a.url {
+			t.Errorf("%s resolved to %q, want %q", a.name, got, a.url)
+		}
+	}
+}
+
+func TestProxyEvictsLeastRecentlyUsed(t *testing.T) {
+	d := &DLNAPlayer{}
+
+	oldest := d.addURLToProxy("http://server/0")
+	for i := 1; i < len(d.proxyURLs); i++ {
+		d.addURLToProxy("http://server/" + string(rune('a'+i)))
+	}
+	// still the least recently used, so the next insert drops it
+	if _, ok := d.lookupProxyURL(oldest); !ok {
+		t.Fatal("proxy dropped an entry while it still had room")
+	}
+
+	// the lookup above promoted it, so refill past capacity to evict it
+	for i := range d.proxyURLs {
+		d.addURLToProxy("http://server/new" + string(rune('a'+i)))
+	}
+	if _, ok := d.lookupProxyURL(oldest); ok {
+		t.Error("expected the least recently used entry to be evicted")
+	}
+}

--- a/backend/player/sonos/topology.go
+++ b/backend/player/sonos/topology.go
@@ -1,0 +1,218 @@
+// Package sonos resolves the zone group topology of a Sonos system.
+//
+// Sonos players are ordinary UPnP MediaRenderers, but each one advertises
+// itself individually - including the halves of a stereo pair and the
+// satellites of a home theater set, which a user never addresses on its
+// own. The ZoneGroupTopology service describes how the players are really
+// arranged, which of them are hidden, and which one coordinates playback
+// for the rest. Casting has to be driven through that coordinator.
+package sonos
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/supersonic-app/go-upnpcast/device"
+)
+
+const (
+	topologyServiceType = "urn:schemas-upnp-org:service:ZoneGroupTopology:1"
+	topologyControlPath = "/ZoneGroupTopology/Control"
+
+	// Sonos players always serve their UPnP endpoints on port 1400.
+	sonosPort = "1400"
+
+	getZoneGroupStateBody = `<?xml version="1.0" encoding="utf-8"?>` +
+		`<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"` +
+		` s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body>` +
+		`<u:GetZoneGroupState xmlns:u="` + topologyServiceType + `"></u:GetZoneGroupState>` +
+		`</s:Body></s:Envelope>`
+)
+
+// A Group is a set of Sonos players that plays as a unit: a lone speaker,
+// a bonded stereo pair or home theater set, or several rooms the user has
+// grouped together. Playback is driven through Coordinator.
+type Group struct {
+	Name        string
+	Coordinator *device.MediaRenderer
+}
+
+// Groups sorts discovered renderers into the Sonos zone groups they belong
+// to, and the renderers that are not part of a Sonos system. Every Sonos
+// player is claimed by the topology, so a player that is not separately
+// addressable is dropped rather than returned as a renderer of its own.
+//
+// If no Sonos system answers, every renderer is returned as an "other".
+func Groups(ctx context.Context, renderers []*device.MediaRenderer) (groups []Group, others []*device.MediaRenderer) {
+	// The topology covers the whole household, so the first player to
+	// answer describes every other one.
+	var state zoneGroupState
+	for _, r := range renderers {
+		if !mayBeSonos(r) {
+			continue
+		}
+		if s, err := getZoneGroupState(ctx, r.URL); err == nil {
+			state = s
+			break
+		}
+	}
+	return state.group(renderers)
+}
+
+// group matches the topology against the renderers that were actually
+// discovered, splitting them into playable zone groups and non-Sonos
+// leftovers.
+func (s zoneGroupState) group(renderers []*device.MediaRenderer) (groups []Group, others []*device.MediaRenderer) {
+	byLocation := make(map[string]*device.MediaRenderer, len(renderers))
+	for _, r := range renderers {
+		byLocation[r.URL] = r
+	}
+
+	claimed := make(map[string]bool)
+	for _, g := range s.Groups {
+		var visible []zoneGroupMember
+		for _, m := range g.members() {
+			claimed[m.Location] = true
+			if !m.hidden() {
+				visible = append(visible, m)
+			}
+		}
+
+		coordinator, ok := byLocation[g.coordinatorLocation()]
+		if !ok || len(visible) == 0 {
+			continue // not reachable, or nothing the user would target
+		}
+		groups = append(groups, Group{
+			Name:        groupName(g.zoneName(), len(visible)),
+			Coordinator: coordinator,
+		})
+	}
+	slices.SortFunc(groups, func(a, b Group) int { return strings.Compare(a.Name, b.Name) })
+
+	for _, r := range renderers {
+		if !claimed[r.URL] {
+			others = append(others, r)
+		}
+	}
+	return groups, others
+}
+
+// groupName names a zone group the way the Sonos app does: the
+// coordinator's room, plus a count of the other rooms playing along.
+func groupName(zoneName string, visibleMembers int) string {
+	if visibleMembers < 2 {
+		return zoneName
+	}
+	return fmt.Sprintf("%s + %d", zoneName, visibleMembers-1)
+}
+
+func mayBeSonos(d *device.MediaRenderer) bool {
+	u, err := url.Parse(d.URL)
+	return err == nil && u.Port() == sonosPort
+}
+
+func getZoneGroupState(ctx context.Context, deviceURL string) (zoneGroupState, error) {
+	u, err := url.Parse(deviceURL)
+	if err != nil {
+		return zoneGroupState{}, err
+	}
+	controlURL := u.Scheme + "://" + u.Host + topologyControlPath
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, controlURL,
+		strings.NewReader(getZoneGroupStateBody))
+	if err != nil {
+		return zoneGroupState{}, err
+	}
+	req.Header.Set("Content-Type", `text/xml; charset="utf-8"`)
+	req.Header.Set("SOAPAction", `"`+topologyServiceType+`#GetZoneGroupState"`)
+	req.Header.Set("Connection", "close")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return zoneGroupState{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return zoneGroupState{}, fmt.Errorf("zone group topology returned %s", resp.Status)
+	}
+
+	// The state is an XML document escaped into the SOAP response.
+	var envelope zoneGroupStateEnvelope
+	if err := xml.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return zoneGroupState{}, err
+	}
+	var state zoneGroupState
+	if err := xml.Unmarshal([]byte(envelope.State), &state); err != nil {
+		return zoneGroupState{}, err
+	}
+	return state, nil
+}
+
+type zoneGroupStateEnvelope struct {
+	XMLName xml.Name `xml:"Envelope"`
+	State   string   `xml:"Body>GetZoneGroupStateResponse>ZoneGroupState"`
+}
+
+type zoneGroupState struct {
+	XMLName xml.Name    `xml:"ZoneGroupState"`
+	Groups  []zoneGroup `xml:"ZoneGroups>ZoneGroup"`
+}
+
+type zoneGroup struct {
+	Coordinator string            `xml:"Coordinator,attr"`
+	Members     []zoneGroupMember `xml:"ZoneGroupMember"`
+}
+
+type zoneGroupMember struct {
+	UUID      string `xml:"UUID,attr"`
+	ZoneName  string `xml:"ZoneName,attr"`
+	Location  string `xml:"Location,attr"`
+	Invisible string `xml:"Invisible,attr"`
+
+	// Satellites are the surrounds and subwoofer bonded to a home
+	// theater player. They are hidden members of their host's zone.
+	Satellites []zoneGroupMember `xml:"Satellite"`
+}
+
+// members flattens the group's players, satellites included.
+func (g zoneGroup) members() []zoneGroupMember {
+	var all []zoneGroupMember
+	for _, m := range g.Members {
+		all = append(all, m)
+		all = append(all, m.Satellites...)
+	}
+	return all
+}
+
+func (g zoneGroup) coordinator() (zoneGroupMember, bool) {
+	for _, m := range g.Members {
+		if m.UUID == g.Coordinator {
+			return m, true
+		}
+	}
+	return zoneGroupMember{}, false
+}
+
+func (g zoneGroup) coordinatorLocation() string {
+	c, _ := g.coordinator()
+	return c.Location
+}
+
+func (g zoneGroup) zoneName() string {
+	c, _ := g.coordinator()
+	return c.ZoneName
+}
+
+// hidden reports whether the player is bonded to another one - the second
+// speaker of a stereo pair, or a home theater satellite - and so is not
+// something the user can play to on its own.
+func (m zoneGroupMember) hidden() bool {
+	return m.Invisible == "1"
+}

--- a/backend/player/sonos/topology_test.go
+++ b/backend/player/sonos/topology_test.go
@@ -1,0 +1,137 @@
+package sonos
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/supersonic-app/go-upnpcast/device"
+)
+
+// Captured from a household with a standalone Era 300 ("Office") and a
+// stereo pair of Sonos Ones ("Bedroom"), whose right speaker coordinates
+// the pair and whose left speaker is invisible.
+const pairAndStandaloneState = `<ZoneGroupState><ZoneGroups>` +
+	`<ZoneGroup Coordinator="RINCON_ERA300" ID="RINCON_ERA300:1001672193">` +
+	`<ZoneGroupMember UUID="RINCON_ERA300" Location="http://192.168.1.178:1400/xml/device_description.xml" ZoneName="Office"/>` +
+	`</ZoneGroup>` +
+	`<ZoneGroup Coordinator="RINCON_ONE_RF" ID="RINCON_ONE_RF:2220472879">` +
+	`<ZoneGroupMember UUID="RINCON_ONE_RF" Location="http://192.168.1.111:1400/xml/device_description.xml" ZoneName="Bedroom" ChannelMapSet="RINCON_ONE_RF:RF,RF;RINCON_ONE_LF:LF,LF"/>` +
+	`<ZoneGroupMember UUID="RINCON_ONE_LF" Location="http://192.168.1.233:1400/xml/device_description.xml" ZoneName="Bedroom" Invisible="1" ChannelMapSet="RINCON_ONE_RF:RF,RF;RINCON_ONE_LF:LF,LF"/>` +
+	`</ZoneGroup>` +
+	`</ZoneGroups><VanishedDevices></VanishedDevices></ZoneGroupState>`
+
+func renderers(urls ...string) []*device.MediaRenderer {
+	var r []*device.MediaRenderer
+	for _, u := range urls {
+		r = append(r, &device.MediaRenderer{URL: u, FriendlyName: u})
+	}
+	return r
+}
+
+func parseState(t *testing.T, s string) zoneGroupState {
+	t.Helper()
+	var state zoneGroupState
+	if err := xml.Unmarshal([]byte(s), &state); err != nil {
+		t.Fatalf("failed to parse zone group state: %v", err)
+	}
+	return state
+}
+
+func TestGroupStereoPairAndStandalone(t *testing.T) {
+	state := parseState(t, pairAndStandaloneState)
+	discovered := renderers(
+		"http://192.168.1.233:1400/xml/device_description.xml",
+		"http://192.168.1.111:1400/xml/device_description.xml",
+		"http://192.168.1.178:1400/xml/device_description.xml",
+		"http://192.168.1.50:8200/rootDesc.xml", // a non-Sonos renderer
+	)
+
+	groups, others := state.group(discovered)
+
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 zone groups, got %d: %+v", len(groups), groups)
+	}
+	if groups[0].Name != "Bedroom" {
+		t.Errorf("expected the stereo pair to be named Bedroom, got %q", groups[0].Name)
+	}
+	// The pair must be driven through its coordinator, not the invisible speaker.
+	if want := "http://192.168.1.111:1400/xml/device_description.xml"; groups[0].Coordinator.URL != want {
+		t.Errorf("expected coordinator %q, got %q", want, groups[0].Coordinator.URL)
+	}
+	if groups[1].Name != "Office" {
+		t.Errorf("expected the standalone speaker to be named Office, got %q", groups[1].Name)
+	}
+
+	if len(others) != 1 || others[0].URL != "http://192.168.1.50:8200/rootDesc.xml" {
+		t.Errorf("expected only the non-Sonos renderer to be left over, got %+v", others)
+	}
+}
+
+func TestGroupNamesGroupedRooms(t *testing.T) {
+	state := parseState(t, `<ZoneGroupState><ZoneGroups>`+
+		`<ZoneGroup Coordinator="A" ID="A:1">`+
+		`<ZoneGroupMember UUID="A" Location="http://a:1400/d.xml" ZoneName="Kitchen"/>`+
+		`<ZoneGroupMember UUID="B" Location="http://b:1400/d.xml" ZoneName="Patio"/>`+
+		`<ZoneGroupMember UUID="C" Location="http://c:1400/d.xml" ZoneName="Den"/>`+
+		`</ZoneGroup></ZoneGroups></ZoneGroupState>`)
+
+	groups, others := state.group(renderers("http://a:1400/d.xml", "http://b:1400/d.xml", "http://c:1400/d.xml"))
+
+	if len(groups) != 1 {
+		t.Fatalf("expected grouped rooms to collapse into 1 entry, got %d", len(groups))
+	}
+	if groups[0].Name != "Kitchen + 2" {
+		t.Errorf(`expected "Kitchen + 2", got %q`, groups[0].Name)
+	}
+	if len(others) != 0 {
+		t.Errorf("expected no leftover renderers, got %+v", others)
+	}
+}
+
+func TestGroupHomeTheaterSatellitesAreHidden(t *testing.T) {
+	state := parseState(t, `<ZoneGroupState><ZoneGroups>`+
+		`<ZoneGroup Coordinator="ARC" ID="ARC:1">`+
+		`<ZoneGroupMember UUID="ARC" Location="http://arc:1400/d.xml" ZoneName="Living Room">`+
+		`<Satellite UUID="SUB" Location="http://sub:1400/d.xml" ZoneName="Living Room" Invisible="1"/>`+
+		`<Satellite UUID="SURR" Location="http://surr:1400/d.xml" ZoneName="Living Room" Invisible="1"/>`+
+		`</ZoneGroupMember></ZoneGroup></ZoneGroups></ZoneGroupState>`)
+
+	groups, others := state.group(renderers("http://arc:1400/d.xml", "http://sub:1400/d.xml", "http://surr:1400/d.xml"))
+
+	if len(groups) != 1 || groups[0].Name != "Living Room" {
+		t.Fatalf(`expected a single "Living Room" entry, got %+v`, groups)
+	}
+	if len(others) != 0 {
+		t.Errorf("expected satellites to be claimed by the topology, got %+v", others)
+	}
+}
+
+// A Sonos player that answers SSDP but is missing from the topology (or
+// whose coordinator is) must not fall through to the plain DLNA list.
+func TestGroupSkipsUnreachableCoordinator(t *testing.T) {
+	state := parseState(t, `<ZoneGroupState><ZoneGroups>`+
+		`<ZoneGroup Coordinator="A" ID="A:1">`+
+		`<ZoneGroupMember UUID="A" Location="http://a:1400/d.xml" ZoneName="Kitchen"/>`+
+		`<ZoneGroupMember UUID="B" Location="http://b:1400/d.xml" ZoneName="Patio"/>`+
+		`</ZoneGroup></ZoneGroups></ZoneGroupState>`)
+
+	groups, others := state.group(renderers("http://b:1400/d.xml"))
+
+	if len(groups) != 0 {
+		t.Errorf("expected no playable groups without the coordinator, got %+v", groups)
+	}
+	if len(others) != 0 {
+		t.Errorf("expected the Sonos member to stay claimed, got %+v", others)
+	}
+}
+
+func TestGroupWithoutSonosLeavesRenderersAlone(t *testing.T) {
+	groups, others := zoneGroupState{}.group(renderers("http://tv:8200/rootDesc.xml"))
+
+	if len(groups) != 0 {
+		t.Errorf("expected no groups, got %+v", groups)
+	}
+	if len(others) != 1 {
+		t.Fatalf("expected the renderer to be passed through, got %+v", others)
+	}
+}


### PR DESCRIPTION
Adds Sonos support.

Closes #594.

Sonos speakers show up in discovery already, but casting to one fails and
they're listed one entry per speaker rather than per room.

Four changes:

**Content-Length on control requests.** This is what breaks casting.
go-upnpcast builds SOAP bodies from readers, so net/http sends them chunked,
and Sonos never answers a chunked control request — it just hangs until the
timeout. Buffered in a RoundTripper for now, but the real fix belongs upstream.

**Zone group topology.** Every Sonos player advertises its own MediaRenderer,
so a stereo pair is two entries and a home theatre set one per satellite, all
named after the RINCON renderer name. New backend/player/sonos resolves
ZoneGroupTopology (one call covers the whole household) and lists one entry
per group, named after the room, driven through the coordinator. Non-Sonos
renderers pass through untouched; if nothing answers, the old DLNA list stands.

**Four DLNA playback fixes**, all pre-existing, all easy to hit on Sonos:
- a muted renderer stayed muted on connect, with no way to unmute from the UI
- the proxy held 3 URLs, from before cover art went through it too. Current +
  next track need 4, so setting the next track evicted the current stream and
  a seek 404'd, letting the renderer skip ahead. Intermittent, since tracks
  from the same album share art
- failedToSetNext was never cleared on success, so a stale item could get
  played at a later track change
- seeking after a mid-track player switch raced the device still loading.
  Sonos answers that seek 200 OK and ignores it. Now waits for the transition
  instead of sleeping 2s (replaces the TODO there), which also makes the switch
  ~260ms

**End of queue.** Only fired the local OnStopped callback and let the stream run
off the end. Sonos then resumes whatever session it was playing before, so
ending the queue started someone else's music. Pausing holds it; note that Stop
does not — Sonos reads that as the session ending and resumes too.

Only the topology commit is Sonos-sp renderer.

Tested against an Era 300 and a bonded pair of Sonos Ones: 3 renderers collapse
to 2 named groups, and connect/volume/play/gapless/seek/pause/end of queue all
verified end to end.
