### PR TITLE
dlna: fix track-change timer deadlock on concurrent Reset calls

### DIFF
--- a/backend/player/dlna/dlnaplayer.go
+++ b/backend/player/dlna/dlnaplayer.go
@@ -90,9 +90,7 @@ type DLNAPlayer struct {
 	failedToSetNext    bool
 	unsetNextMediaItem *avtransport.MediaItem
 
-	timerActive atomic.Bool
-	timer       *time.Timer
-	resetChan   chan (time.Duration)
+	trackChangeTimer *trackChangeTimer
 }
 
 func NewDLNAPlayer(device *device.MediaRenderer, coverArtPathFn func(coverArtID string) (string, error)) (*DLNAPlayer, error) {
@@ -120,12 +118,14 @@ func NewDLNAPlayer(device *device.MediaRenderer, coverArtPathFn func(coverArtID 
 		return nil, fmt.Errorf("failed to connect to %s", device.FriendlyName)
 	}
 
-	return &DLNAPlayer{
+	d := &DLNAPlayer{
 		avTransport:    avt,
 		renderControl:  rc,
-		resetChan:      make(chan time.Duration),
 		coverArtPathFn: coverArtPathFn,
-	}, nil
+	}
+	d.trackChangeTimer = newTrackChangeTimer(d.handleOnTrackChange)
+
+	return d, nil
 }
 
 // buildMediaItem assembles the avtransport.MediaItem for a track. It
@@ -219,7 +219,7 @@ func (d *DLNAPlayer) PlayFile(urlstr string, meta mediaprovider.MediaItemMetadat
 	}
 	d.state = playing
 	remainingDur := meta.Duration - time.Duration(startTime)*time.Second
-	d.setTrackChangeTimer(remainingDur)
+	d.trackChangeTimer.Reset(remainingDur)
 	d.stopwatch.Reset()
 	d.stopwatch.Start()
 	d.lastStartTime = int(startTime)
@@ -304,7 +304,7 @@ func (d *DLNAPlayer) Continue() error {
 	nextTrackChange := d.curTrackMeta.Duration - d.curPlayPos()
 	d.metaLock.Unlock()
 	d.state = playing
-	d.setTrackChangeTimer(nextTrackChange)
+	d.trackChangeTimer.Reset(nextTrackChange)
 	d.stopwatch.Start()
 	d.InvokeOnPlaying()
 	return nil
@@ -321,7 +321,7 @@ func (d *DLNAPlayer) Pause() error {
 	if err := d.avTransport.Pause(ctx); err != nil {
 		return err
 	}
-	d.setTrackChangeTimer(0)
+	d.trackChangeTimer.Reset(0)
 	d.stopwatch.Stop()
 	d.state = paused
 	d.InvokeOnPaused()
@@ -355,7 +355,7 @@ func (d *DLNAPlayer) Stop(force bool) error {
 		}
 		fallthrough
 	case paused:
-		d.setTrackChangeTimer(0)
+		d.trackChangeTimer.Reset(0)
 		d.stopwatch.Reset()
 		d.lastStartTime = 0
 		d.state = stopped
@@ -387,7 +387,7 @@ func (d *DLNAPlayer) SeekSeconds(secs float64) error {
 		d.metaLock.Lock()
 		nextTrackChange := d.curTrackMeta.Duration - time.Duration(secs)*time.Second
 		d.metaLock.Unlock()
-		d.setTrackChangeTimer(nextTrackChange)
+		d.trackChangeTimer.Reset(nextTrackChange)
 		d.stopwatch.Start()
 	}
 
@@ -443,7 +443,7 @@ func (d *DLNAPlayer) curPlayPos() time.Duration {
 
 func (d *DLNAPlayer) Destroy() {
 	d.destroyed = true
-	d.setTrackChangeTimer(0)
+	d.trackChangeTimer.Reset(0)
 	if d.cancelRequest != nil {
 		d.cancelRequest()
 	}
@@ -464,7 +464,7 @@ func (d *DLNAPlayer) syncPlaybackTime() {
 		if d.state == playing {
 			d.stopwatch.Start()
 		}
-		d.setTrackChangeTimer(d.curTrackMeta.Duration - time.Duration(d.lastStartTime)*time.Second)
+		d.trackChangeTimer.Reset(d.curTrackMeta.Duration - time.Duration(d.lastStartTime)*time.Second)
 		d.InvokeOnSeek()
 	}
 }
@@ -492,51 +492,6 @@ func (d *DLNAPlayer) ensureSetupProxy() error {
 
 	go d.proxyServer.Serve(listener)
 	return nil
-}
-
-func (d *DLNAPlayer) setTrackChangeTimer(dur time.Duration) {
-	if d.timerActive.Swap(true) {
-		// was active
-		d.resetChan <- dur
-		return
-	}
-	if dur == 0 {
-		d.timerActive.Store(false)
-		return
-	}
-
-	d.timer = time.NewTimer(dur)
-	go func() {
-		for {
-			select {
-			case dur := <-d.resetChan:
-				if dur == 0 {
-					d.timerActive.Store(false)
-					if !d.timer.Stop() {
-						select {
-						case <-d.timer.C:
-						default:
-						}
-					}
-					d.timer = nil
-					return
-				}
-				// reset the timer
-				if !d.timer.Stop() {
-					select {
-					case <-d.timer.C:
-					default:
-					}
-				}
-				d.timer.Reset(dur)
-			case <-d.timer.C:
-				d.timerActive.Store(false)
-				d.timer = nil
-				d.handleOnTrackChange()
-				return
-			}
-		}
-	}()
 }
 
 func (d *DLNAPlayer) handleOnTrackChange() {
@@ -569,7 +524,7 @@ func (d *DLNAPlayer) handleOnTrackChange() {
 		d.lastStartTime = 0
 		d.stopwatch.Reset()
 		d.stopwatch.Start()
-		d.setTrackChangeTimer(nextTrackChange)
+		d.trackChangeTimer.Reset(nextTrackChange)
 		d.InvokeOnTrackChange()
 
 		go func() {

--- a/backend/player/dlna/trackchangetimer.go
+++ b/backend/player/dlna/trackchangetimer.go
@@ -1,0 +1,47 @@
+package dlna
+
+import (
+	"sync"
+	"time"
+)
+
+// trackChangeTimer is a resettable one-shot timer used to estimate when the
+// current track will end, since DLNA/UPnP has no push mechanism for
+// transport-state changes.
+//
+// Reset is safe to call concurrently from multiple goroutines (e.g. a
+// user-initiated Stop() racing the delayed background position sync kicked
+// off after PlayFile/SeekSeconds/handleOnTrackChange), which the previous
+// implementation based on an unbuffered channel handoff to a dispatcher
+// goroutine was not: two concurrent Reset calls could race such that one
+// delivers a "cancel" that causes the dispatcher to exit while the other,
+// already in-flight send, is still waiting for a receiver - blocking that
+// caller (and anything serialized behind it, such as the playback command
+// queue) forever.
+type trackChangeTimer struct {
+	mu    sync.Mutex
+	timer *time.Timer
+
+	onFire func()
+}
+
+func newTrackChangeTimer(onFire func()) *trackChangeTimer {
+	return &trackChangeTimer{onFire: onFire}
+}
+
+// Reset (re)arms the timer to fire onFire after dur, replacing any
+// previously scheduled fire. A dur of exactly 0 cancels any pending fire
+// without scheduling a new one.
+func (t *trackChangeTimer) Reset(dur time.Duration) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.timer != nil {
+		t.timer.Stop()
+		t.timer = nil
+	}
+	if dur == 0 {
+		return
+	}
+	t.timer = time.AfterFunc(dur, t.onFire)
+}

--- a/backend/player/dlna/trackchangetimer_test.go
+++ b/backend/player/dlna/trackchangetimer_test.go
@@ -1,0 +1,76 @@
+package dlna
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestTrackChangeTimer_ConcurrentReset reproduces the scenario that used to
+// deadlock: many goroutines calling Reset(0) (cancel, e.g. from Stop/Pause)
+// concurrently with others calling Reset(nonzero) (re-arm, e.g. from a
+// delayed background position sync). With the old unbuffered-channel-based
+// implementation, a Reset(0) landing first could cause the timer's
+// dispatcher goroutine to exit while a concurrent Reset(nonzero) call was
+// still blocked sending to it, hanging that caller (and anything serialized
+// behind it) forever.
+func TestTrackChangeTimer_ConcurrentReset(t *testing.T) {
+	timer := newTrackChangeTimer(func() {})
+	timer.Reset(50 * time.Millisecond)
+
+	const n = 100
+	var wg sync.WaitGroup
+	wg.Add(2 * n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			timer.Reset(0)
+		}()
+		go func() {
+			defer wg.Done()
+			timer.Reset(10 * time.Millisecond)
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// all Reset calls returned - no deadlock
+	case <-time.After(5 * time.Second):
+		t.Fatal("Reset calls did not return in time - possible deadlock")
+	}
+}
+
+// TestTrackChangeTimer_FiresAndCancels checks the basic contract: a
+// scheduled fire actually invokes the callback, and Reset(0) suppresses a
+// fire that hasn't happened yet.
+func TestTrackChangeTimer_FiresAndCancels(t *testing.T) {
+	fired := make(chan struct{}, 1)
+	timer := newTrackChangeTimer(func() {
+		select {
+		case fired <- struct{}{}:
+		default:
+		}
+	})
+
+	timer.Reset(20 * time.Millisecond)
+	select {
+	case <-fired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("callback did not fire")
+	}
+
+	timer.Reset(50 * time.Millisecond)
+	timer.Reset(0)
+	select {
+	case <-fired:
+		t.Fatal("callback fired after being cancelled")
+	case <-time.After(150 * time.Millisecond):
+		// expected: no fire
+	}
+}


### PR DESCRIPTION
Fixes #1027

## Problem

`DLNAPlayer`'s track-change timer (`setTrackChangeTimer`/`Reset`) handed off cancel/reschedule requests to a dispatcher goroutine over an unbuffered channel. If two `Reset()` calls raced - e.g. `Stop()`'s `Reset(0)` (cancel) against the background goroutine that `PlayFile`/`SeekSeconds`/`handleOnTrackChange` spawn to call `syncPlaybackTime()` a few seconds later, which itself calls `Reset(nonzero)` - and the dispatcher received the `Reset(0)` first, it would exit immediately, permanently orphaning the other, still-blocked sender.

That caller (e.g. `Stop()`, called from `PlaybackManager.SetRemotePlayer` while switching remote players) would then hang forever, wedging the single-goroutine playback command queue and freezing all playback controls.

## Fix

Extracted the timer into its own `trackChangeTimer` type (`backend/player/dlna/trackchangetimer.go`) and replaced the channel/`atomic.Bool` dispatcher-goroutine design with a mutex-protected `*time.Timer` + `time.AfterFunc`, which has no handoff race to begin with. Same behavior, no changes needed at any call site beyond `d.setTrackChangeTimer(x)` → `d.trackChangeTimer.Reset(x)`.

Added a regression test (`trackchangetimer_test.go`) that reliably deadlocks against the old implementation (verified manually) and passes cleanly against the new one.

## Testing

- `go build ./...`
- `go vet ./backend/player/dlna/...`
- `go test -race ./backend/player/dlna/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)