### PR TITLE
fix(playback): guard against out-of-bounds queue access on track change

### DIFF
--- a/backend/playbackengine.go
+++ b/backend/playbackengine.go
@@ -293,7 +293,11 @@ func (p *playbackEngine) setShuffledPlayQueue(items []mediaprovider.MediaItem) {
 }
 
 func (p *playbackEngine) getPlayQueueItemAt(idx int) mediaprovider.MediaItem {
-	return p.getActivePlayQueue()[idx]
+	queue := p.getActivePlayQueue()
+	if idx < 0 || idx >= len(queue) {
+		return nil
+	}
+	return queue[idx]
 }
 
 func (p *playbackEngine) insertItemsIntoPlayQueueAt(items []mediaprovider.MediaItem, idx int, queueType QueueType) {
@@ -373,7 +377,7 @@ func (p *playbackEngine) playTrackAt(idx int, startTime float64) error {
 
 // Gets the curently playing media item, if any.
 func (p *playbackEngine) NowPlaying() mediaprovider.MediaItem {
-	if p.nowPlayingIdx < 0 || p.getPlayQueueLength() == 0 {
+	if p.nowPlayingIdx < 0 {
 		return nil
 	}
 	if !p.pendingLoadPaused && p.player.GetStatus().State == player.Stopped {
@@ -915,6 +919,10 @@ func (p *playbackEngine) handleOnTrackChange() {
 		p.pendingTrackChangeNum = -1
 	}
 	nowPlaying := p.getPlayQueueItemAt(p.nowPlayingIdx)
+	if nowPlaying == nil {
+		p.handleOnStopped()
+		return
+	}
 	_, isRadio := nowPlaying.(*mediaprovider.RadioStation)
 	p.isRadio = isRadio
 


### PR DESCRIPTION
### Summary
Safely handle out-of-bounds indices in `getPlayQueueItemAt` by returning `nil` instead of panicking.

In `handleOnTrackChange`, stop playback cleanly if the current item is `nil`. This avoids runtime panics (`index out of range` and `nil pointer dereference`) when the play queue is cleared, reduced, or reordered while an asynchronous track change event is in flight.